### PR TITLE
Modularization uniformity for ZNE, PEC, DDD, and LRE

### DIFF
--- a/docs/source/examples/lre-zne-comparison.md
+++ b/docs/source/examples/lre-zne-comparison.md
@@ -146,7 +146,7 @@ Next for ZNE.
 
 ```{code-cell} ipython3
 from mitiq.zne.scaling import fold_gates_at_random
-from mitiq.zne.zne import construct_circuits
+from mitiq.zne import construct_circuits
 
 scale_factors = [1.0, 2.0, 3.0]
 

--- a/docs/source/examples/lre-zne-comparison.md
+++ b/docs/source/examples/lre-zne-comparison.md
@@ -146,7 +146,7 @@ Next for ZNE.
 
 ```{code-cell} ipython3
 from mitiq.zne.scaling import fold_gates_at_random
-from mitiq.zne.zne import scaled_circuits
+from mitiq.zne.zne import construct_circuits
 
 scale_factors = [1.0, 2.0, 3.0]
 
@@ -154,7 +154,7 @@ avg_num_scaled_circuits_zne = 0.0
 avg_depth_scaled_circuits_zne = 0.0
 
 for circuit in circuits:
-    noise_scaled_circuits_zne = scaled_circuits(
+    noise_scaled_circuits_zne = construct_circuits(
         circuit=circuit,
         scale_factors=[1.0, 2.0, 3.0],
         scale_method=fold_gates_at_random,

--- a/docs/source/guide/ddd-1-intro.md
+++ b/docs/source/guide/ddd-1-intro.md
@@ -17,7 +17,7 @@ DDD works in two main stages: generate noise-scaled circuits by inserting DDD se
 The section [Apply DDD](#apply-ddd) applies the protocol in a single step, and then in the section [Step by step application of DDD](#step-by-step-application-of-ddd), we’ll show how you can apply the technique stepwise.
 
 This workflow can be executed by a single call to {func}`.execute_with_ddd`.
-If more control is needed over the protocol, Mitiq provides {func}`.construct_circuits` and {func}`.ddd.combine_results` to handle the first and second steps respectively.
+If more control is needed over the protocol, Mitiq provides {func}`.ddd.construct_circuits` and {func}`.ddd.combine_results` to handle the first and second steps respectively.
 
 As with all techniques, DDD is compatible with any frontend supported by Mitiq:
 
@@ -118,7 +118,7 @@ the error with DDD is sometimes larger than the unmitigated error.
 
 ## Step by step application of DDD
 
-In this section we demonstrate the use of {func}`.construct_circuits` for those who might want to generate circuits with DDD sequences inserted, and have more control over the protocol.
+In this section we demonstrate the use of {func}`.ddd.construct_circuits` for those who might want to generate circuits with DDD sequences inserted, and have more control over the protocol.
 
 ### Generating circuits with DDD sequences
 

--- a/docs/source/guide/ddd-1-intro.md
+++ b/docs/source/guide/ddd-1-intro.md
@@ -17,7 +17,7 @@ DDD works in two main stages: generate noise-scaled circuits by inserting DDD se
 The section [Apply DDD](#apply-ddd) applies the protocol in a single step, and then in the section [Step by step application of DDD](#step-by-step-application-of-ddd), we’ll show how you can apply the technique stepwise.
 
 This workflow can be executed by a single call to {func}`.execute_with_ddd`.
-If more control is needed over the protocol, Mitiq provides {func}`.generate_circuits_with_ddd` and {func}`.ddd.combine_results` to handle the first and second steps respectively.
+If more control is needed over the protocol, Mitiq provides {func}`.construct_circuits` and {func}`.ddd.combine_results` to handle the first and second steps respectively.
 
 As with all techniques, DDD is compatible with any frontend supported by Mitiq:
 
@@ -118,14 +118,14 @@ the error with DDD is sometimes larger than the unmitigated error.
 
 ## Step by step application of DDD
 
-In this section we demonstrate the use of {func}`.generate_circuits_with_ddd` for those who might want to generate circuits with DDD sequences inserted, and have more control over the protocol.
+In this section we demonstrate the use of {func}`.construct_circuits` for those who might want to generate circuits with DDD sequences inserted, and have more control over the protocol.
 
 ### Generating circuits with DDD sequences
 
 Here we will generate a list of circuits with DDD sequences inserted, which will later be passed to the executor. The number of circuits generated can be checked using the `len` function.
 
 ```{code-cell} ipython3
-circuits_with_ddd = ddd.generate_circuits_with_ddd(circuit=circuit, rule=rule, num_trials=10)
+circuits_with_ddd = ddd.construct_circuits(circuit=circuit, rule=rule, num_trials=10)
 
 print(f"Number of sample circuits:    {len(circuits_with_ddd)}")
 print(circuits_with_ddd[0])

--- a/docs/source/guide/pec-1-intro.md
+++ b/docs/source/guide/pec-1-intro.md
@@ -33,7 +33,7 @@ PEC works in two main stages: generate noise-scaled circuits via inserting quasi
 The section [Run PEC](#run-pec) applies the protocol in a single step, and then in the section [Step by step application of PEC](#step-by-step-application-of-pec), we'll show how you can apply the technique stepwise.
 
 This workflow can be executed by a single call to {func}`.execute_with_pec`.
-If more control is needed over the protocol, Mitiq provides {func}`.construct_circuits` and {func}`.pec.combine_results` to handle the first and second steps respectively.
+If more control is needed over the protocol, Mitiq provides {func}`.pec.construct_circuits` and {func}`.pec.combine_results` to handle the first and second steps respectively.
 
 As with all techniques, PEC is compatible with any frontend supported by Mitiq:
 
@@ -186,7 +186,7 @@ As printed above, PEC reduced the error compared to the unmitigated case.
 
 ## Step by step application of PEC
 
-This section demonstrates the use of the {func}`.construct_circuits` for those who want to generate and see a list of sampled circuits based on the given quasi-probability representaions.
+This section demonstrates the use of the {func}`.pec.construct_circuits` for those who want to generate and see a list of sampled circuits based on the given quasi-probability representaions.
 
 ### Generate Sample Circuits
 We will now generate a list of sampled circuits. Note that the number of sampled circuits generated depends on the input provided, which can be seen using the function `len`.

--- a/docs/source/guide/pec-1-intro.md
+++ b/docs/source/guide/pec-1-intro.md
@@ -33,7 +33,7 @@ PEC works in two main stages: generate noise-scaled circuits via inserting quasi
 The section [Run PEC](#run-pec) applies the protocol in a single step, and then in the section [Step by step application of PEC](#step-by-step-application-of-pec), we'll show how you can apply the technique stepwise.
 
 This workflow can be executed by a single call to {func}`.execute_with_pec`.
-If more control is needed over the protocol, Mitiq provides {func}`.generate_sampled_circuits` and {func}`.pec.combine_results` to handle the first and second steps respectively.
+If more control is needed over the protocol, Mitiq provides {func}`.construct_circuits` and {func}`.pec.combine_results` to handle the first and second steps respectively.
 
 As with all techniques, PEC is compatible with any frontend supported by Mitiq:
 
@@ -186,13 +186,13 @@ As printed above, PEC reduced the error compared to the unmitigated case.
 
 ## Step by step application of PEC
 
-This section demonstrates the use of the {func}`.generate_sampled_circuits` for those who want to generate and see a list of sampled circuits based on the given quasi-probability representaions.
+This section demonstrates the use of the {func}`.construct_circuits` for those who want to generate and see a list of sampled circuits based on the given quasi-probability representaions.
 
 ### Generate Sample Circuits
 We will now generate a list of sampled circuits. Note that the number of sampled circuits generated depends on the input provided, which can be seen using the function `len`.
 
 ```{code-cell} ipython3
-sampled_circuits = pec.generate_sampled_circuits(circuit, representations=reps)
+sampled_circuits = pec.construct_circuits(circuit, representations=reps)
 
 print(f"Number of sample circuits:    {len(sampled_circuits)}")
 print(sampled_circuits[0])

--- a/docs/source/guide/zne-1-intro.md
+++ b/docs/source/guide/zne-1-intro.md
@@ -163,7 +163,7 @@ contains more information on both noise scaling and noise extrapolation methods 
 
 ## Two-stage application of ZNE
 
-If you want to have more control and insight into how ZNE works, there are two functions available within `mitiq.zne` that allow circuit generation {func}`.zne.scaled_circuits`, and expectation value calculation {func}`.zne.combine_results` respectively.
+If you want to have more control and insight into how ZNE works, there are two functions available within `mitiq.zne` that allow circuit generation {func}`.zne.construct_circuits`, and expectation value calculation {func}`.zne.combine_results` respectively.
 The high-level workflow is as follows.
 
 1. Circuit definition
@@ -176,12 +176,12 @@ For step 2, we'll generate the noise scaled circuits as follows.
 
 
 ```{code-cell} ipython3
-from mitiq.zne import scaled_circuits, combine_results
+from mitiq.zne import construct_circuits, combine_results
 from mitiq.zne.scaling import fold_gates_at_random
 
 scale_factors = [1.0, 2.0, 3.0]
 
-folded_circuits = scaled_circuits(
+folded_circuits = construct_circuits(
     circuit=circuit,
     scale_factors=[1.0, 2.0, 3.0],
     scale_method=fold_gates_at_random,

--- a/mitiq/ddd/__init__.py
+++ b/mitiq/ddd/__init__.py
@@ -14,4 +14,4 @@ from mitiq.ddd.insertion import (
     insert_ddd_sequences,
 )
 
-from mitiq.ddd.ddd import execute_with_ddd, mitigate_executor, ddd_decorator, generate_circuits_with_ddd, combine_results
+from mitiq.ddd.ddd import execute_with_ddd, mitigate_executor, ddd_decorator, construct_circuits, combine_results

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -60,7 +60,7 @@ def execute_with_ddd(
         executor = Executor(executor)
 
     # Insert DDD sequences in (a copy of) the input circuit
-    circuits_with_ddd = generate_circuits_with_ddd(
+    circuits_with_ddd = construct_circuits(
         circuit, rule, rule_args, num_trials
     )
 
@@ -98,7 +98,7 @@ def combine_results(results: list[float]) -> float:
     return float(np.average(results))
 
 
-def generate_circuits_with_ddd(
+def construct_circuits(
     circuit: QPROGRAM,
     rule: Callable[[int], QPROGRAM],
     rule_args: Dict[str, Any] = {},

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -13,9 +13,9 @@ from pytest import mark
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES, Executor
 from mitiq.ddd import (
+    construct_circuits,
     ddd_decorator,
     execute_with_ddd,
-    generate_circuits_with_ddd,
     mitigate_executor,
 )
 from mitiq.ddd.rules import xx, xyxy, yy
@@ -237,7 +237,7 @@ def test_ddd_decorator_with_rule_args():
 def test_num_trials_generates_circuits(num_trials: int):
     """Test that the number of generated circuits follows num_trials."""
 
-    circuits = generate_circuits_with_ddd(
+    circuits = construct_circuits(
         circuit_cirq_a, rule=xx, num_trials=num_trials
     )
 

--- a/mitiq/lre/__init__.py
+++ b/mitiq/lre/__init__.py
@@ -5,7 +5,7 @@
 
 """Methods for scaling noise in circuits by layers and using multivariate extrapolation."""
 
-from mitiq.lre.lre import execute_with_lre, mitigate_executor, lre_decorator
+from mitiq.lre.lre import execute_with_lre, mitigate_executor, lre_decorator, construct_circuits, combine_results
 
 from mitiq.lre import multivariate_scaling
 

--- a/mitiq/lre/lre.py
+++ b/mitiq/lre/lre.py
@@ -43,8 +43,6 @@ def construct_circuits(
             number of chunks is the same as the layers in the input circuit,
             the input circuit is unchanged.
 
-        circuit: The input circuit to execute with ZNE.
-        scale_factors: An array of noise scale factors.
 
     Returns:
         The scaled circuits using the multivariate_layer_scaling.

--- a/mitiq/lre/lre.py
+++ b/mitiq/lre/lre.py
@@ -38,14 +38,15 @@ def construct_circuits(
         fold_multiplier: Scaling gap value required for unitary folding which
             is used to generate the scale factor vectors.
         folding_method: Unitary folding method. Default is
-            :func:`fold_gates_at_random`.
+            :func:`mitiq.zne.scaling.folding.fold_gates_at_random`.
         num_chunks: Number of desired approximately equal chunks. When the
             number of chunks is the same as the layers in the input circuit,
             the input circuit is unchanged.
 
 
     Returns:
-        The scaled circuits using the multivariate_layer_scaling.
+        The scaled circuits using the
+        :func:`mitiq.lre.multivariate_scaling.layerwise_folding.multivariate_layer_scaling`.
     """
     noise_scaled_circuits = multivariate_layer_scaling(
         circuit, degree, fold_multiplier, num_chunks, folding_method
@@ -66,6 +67,7 @@ def combine_results(
     Extrapolation (LRE).
 
     Args:
+        results: An array storing the results of running the scaled circuits.
         circuit: Circuit to be scaled.
         degree: Degree of the multivariate polynomial.
         fold_multiplier: Scaling gap value required for unitary folding which
@@ -73,7 +75,6 @@ def combine_results(
         num_chunks: Number of desired approximately equal chunks. When the
             number of chunks is the same as the layers in the input circuit,
             the input circuit is unchanged.
-        results: An array storing the results of running the scaled circuits.
 
     Returns:
         The expectation value estimated with LRE.
@@ -120,7 +121,7 @@ def execute_with_lre(
             Otherwise, the ``DensityMatrix`` or ``Bitstrings`` returned by
             ``executor`` is used to compute the expectation of the observable.
         folding_method: Unitary folding method. Default is
-            :func:`fold_gates_at_random`.
+            :func:`mitiq.zne.scaling.folding.fold_gates_at_random`.
         num_chunks: Number of desired approximately equal chunks. When the
             number of chunks is the same as the layers in the input circuit,
             the input circuit is unchanged.
@@ -180,7 +181,7 @@ def mitigate_executor(
             Otherwise, the ``DensityMatrix`` or ``Bitstrings`` returned by
             ``executor`` is used to compute the expectation of the observable.
         folding_method: Unitary folding method. Default is
-            :func:`fold_gates_at_random`.
+            :func:`mitiq.zne.scaling.folding.fold_gates_at_random`.
         num_chunks: Number of desired approximately equal chunks. When the
             number of chunks is the same as the layers in the input circuit,
             the input circuit is unchanged.
@@ -247,7 +248,7 @@ def lre_decorator(
             Otherwise, the ``DensityMatrix`` or ``Bitstrings`` returned by
             ``executor`` is used to compute the expectation of the observable.
         folding_method: Unitary folding method. Default is
-            :func:`fold_gates_at_random`.
+            :func:`mitiq.zne.scaling.folding.fold_gates_at_random`.
         num_chunks: Number of desired approximately equal chunks. When the
             number of chunks is the same as the layers in the input circuit,
             the input circuit is unchanged.

--- a/mitiq/lre/lre.py
+++ b/mitiq/lre/lre.py
@@ -28,21 +28,9 @@ def construct_circuits(
         [QPROGRAM, float], QPROGRAM
     ] = fold_gates_at_random,  # type: ignore [has-type]
     num_chunks: Optional[int] = None,
-    scale_method: Callable[
-        [
-            QPROGRAM,
-            int,
-            int,
-            Optional[int],
-            Callable[[QPROGRAM, float], QPROGRAM],
-        ],
-        list[QPROGRAM],
-    ] = multivariate_layer_scaling,
 ) -> list[QPROGRAM]:
-    """Given a circuit, degree, fold_multiplier, folding_method, num_chunks,
-       and an optional scale_method with a default of
-       multivariate_layer_scaling, outputs a list of circuits that will be used
-       in LRE.
+    """Given a circuit, degree, fold_multiplier, folding_method, and
+       num_chunks, outputs a list of circuits that will be used in LRE.
 
     Args:
         circuit: Circuit to be scaled.
@@ -54,18 +42,14 @@ def construct_circuits(
         num_chunks: Number of desired approximately equal chunks. When the
             number of chunks is the same as the layers in the input circuit,
             the input circuit is unchanged.
-        scale_method: Currently, only multivariate_layer_scaling is available
 
         circuit: The input circuit to execute with ZNE.
         scale_factors: An array of noise scale factors.
-        scale_method: The function for scaling the noise.
-            A list of built-in functions can be found in
-            ``mitiq.lre.multivariate_scaling``.
 
     Returns:
-        The scaled circuits using the scale_method.
+        The scaled circuits using the multivariate_layer_scaling.
     """
-    noise_scaled_circuits = scale_method(
+    noise_scaled_circuits = multivariate_layer_scaling(
         circuit, degree, fold_multiplier, num_chunks, folding_method
     )
     return noise_scaled_circuits

--- a/mitiq/lre/tests/test_lre.py
+++ b/mitiq/lre/tests/test_lre.py
@@ -197,9 +197,9 @@ def test_lre_runs_correct_number_of_circuits_when_chunking():
     )
 
 
-def test_lre_combine_results():
-    """Verify combine_results returns the same results as calling
-    execute_with_lre"""
+def test_two_stage_lre():
+    """Verify construct_circuits generates the appropriate number of circuits
+    and combine_results returns the same results as calling execute_with_lre"""
 
     degree, fold_multiplier = 2, 2
 

--- a/mitiq/pec/__init__.py
+++ b/mitiq/pec/__init__.py
@@ -10,7 +10,7 @@ from mitiq.pec.pec import (
     mitigate_executor,
     pec_decorator,
     combine_results,
-    generate_sampled_circuits,
+    construct_circuits,
 )
 
 from mitiq.pec.representations import (

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -38,7 +38,7 @@ _LARGE_SAMPLE_WARN = (
 )
 
 
-def generate_sampled_circuits(
+def construct_circuits(
     circuit: QPROGRAM,
     representations: Sequence[OperationRepresentation],
     precision: float = 0.03,
@@ -189,7 +189,7 @@ def execute_with_pec(
         ``pec_value``. If ``full_output`` is ``False``, only ``pec_value`` is
         returned.
     """
-    sampled_circuits, signs, norm = generate_sampled_circuits(
+    sampled_circuits, signs, norm = construct_circuits(
         circuit,
         representations,
         precision,

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -22,8 +22,8 @@ from mitiq.pec import (
     NoisyOperation,
     OperationRepresentation,
     combine_results,
+    construct_circuits,
     execute_with_pec,
-    generate_sampled_circuits,
     mitigate_executor,
     pec_decorator,
 )
@@ -369,7 +369,7 @@ def test_execute_with_pec_error_scaling(num_samples: int):
 @pytest.mark.parametrize("precision", [0.2, 0.1])
 def test_precision_option_used_in_num_samples(precision):
     """Tests that the 'precision' argument is used to deduce num_samples."""
-    circuits, _, _ = generate_sampled_circuits(
+    circuits, _, _ = construct_circuits(
         oneq_circ,
         representations=pauli_representations,
         precision=precision,
@@ -384,7 +384,7 @@ def test_precision_option_used_in_num_samples(precision):
 def test_precision_ignored_when_num_samples_present():
     """Check precision is ignored when num_samples is given."""
     num_expected_circuits = 123
-    circuits, _, _ = generate_sampled_circuits(
+    circuits, _, _ = construct_circuits(
         oneq_circ,
         representations=pauli_representations,
         precision=0.1,
@@ -400,7 +400,7 @@ def test_precision_ignored_when_num_samples_present():
 def test_bad_precision_argument(bad_value):
     """Tests that if 'precision' is not within (0, 1] an error is raised."""
     with pytest.raises(ValueError, match="The value of 'precision' should"):
-        generate_sampled_circuits(
+        construct_circuits(
             oneq_circ,
             representations=pauli_representations,
             precision=bad_value,
@@ -414,7 +414,7 @@ def test_large_sample_size_warning(mock_sample_circuit):
     mock_sample_circuit.return_value = ([], [], 0.911)
 
     with pytest.warns(LargeSampleWarning):
-        generate_sampled_circuits(
+        construct_circuits(
             oneq_circ,
             representations=[],
             num_samples=100_001,

--- a/mitiq/zne/__init__.py
+++ b/mitiq/zne/__init__.py
@@ -7,7 +7,7 @@ from mitiq.zne.zne import (
     execute_with_zne,
     mitigate_executor,
     zne_decorator,
-    scaled_circuits,
+    construct_circuits,
     combine_results,
 )
 from mitiq.zne import scaling

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -54,7 +54,7 @@ from mitiq.zne.scaling import (
     get_layer_folding,
     insert_id_layers,
 )
-from mitiq.zne.zne import combine_results, scaled_circuits
+from mitiq.zne.zne import combine_results, construct_circuits
 
 BASE_NOISE = 0.007
 TEST_DEPTH = 30
@@ -603,7 +603,7 @@ def test_two_stage_zne(
         frontend_circuit = cirq_circuit
 
     scale_factors = [1, 3, 5]
-    circs = scaled_circuits(
+    circs = construct_circuits(
         frontend_circuit, scale_factors, noise_scaling_method
     )
 
@@ -643,7 +643,9 @@ def test_default_scaling_option_two_stage_zne():
 
     scale_factors = [3, 5, 6, 8]
 
-    circs_default_scaling_method = scaled_circuits(cirq_circuit, scale_factors)
+    circs_default_scaling_method = construct_circuits(
+        cirq_circuit, scale_factors
+    )
 
     for i in range(len(scale_factors)):
         assert len(circs_default_scaling_method[i]) > len(cirq_circuit)

--- a/mitiq/zne/zne.py
+++ b/mitiq/zne/zne.py
@@ -13,7 +13,7 @@ from mitiq.zne.inference import Factory, RichardsonFactory
 from mitiq.zne.scaling import fold_gates_at_random
 
 
-def scaled_circuits(
+def construct_circuits(
     circuit: QPROGRAM,
     scale_factors: list[float],
     scale_method: Callable[[QPROGRAM, float], QPROGRAM] = fold_gates_at_random,  # type:ignore [has-type]


### PR DESCRIPTION
Fixes #2692 

## Description

The mitigation techniques in the title now have `construct_circuits` and `combine_results` to allow for two stage implementations.

ZNE, PEC, and DDD were straight forward renaming of existing functions. LRE required creating the two functions and a test. Also, during this PR I also made input parameter names conform to ZNE and the other technique's naming scheme.

For LRE's `construct_circuits`, I used ZNE as a template and included a parameter `scale_method` which is defaulted to 
`multivariate_layer_scaling`. My concern is that this is the only scaling method currently available to users. While it leaves open the flexibility for future, I do not know if the plan is to include other options for scaling.

For testing LRE's new functions, I used the ZNE two stage test as an example allowing for testing both the `construct_circuits` and `combine_results`.

> [!NOTE]
> LRE's documentation has NOT been updated yet. It requires a bit more of a re-write than just a few name changes. All other docs have been updated.
---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.

