### PR TITLE
bound numpy from above by 2.0.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.22.0
+numpy>=1.22.0,<2.0.0
 scipy>=1.10.1,<=1.15.2
 cirq-core>=1.4.0,<1.5.0
 tabulate


### PR DESCRIPTION
## Description

Tested this change by creating a new conda env and running `make install` without issue. NumPy 1.26.4 was installed.

fixes https://github.com/unitaryfoundation/mitiq/issues/2704