### PR TITLE
Update get_scale_factors for static scale factors

### DIFF
--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -223,16 +223,14 @@ class Factory(ABC):
         self._options: Dict[str, Optional[float]] = {}
 
     def get_scale_factors(self) -> List[float]:
-        """Returns the scale factors at which the factory has computed
-        expectation values.
+        """Returns the scale factors that were either passed in to the facotry
+        or at which the factory has computed expectation values.
         """
         ret_scale_factors = [
             params.get("scale_factor", 0.0) for params in self._instack
         ]
         if not ret_scale_factors and hasattr(self, "_scale_factors"):
-            return [
-                float(scale_factor) for scale_factor in self._scale_factors
-            ]
+            return [scale_factor for scale_factor in self._scale_factors]
         return ret_scale_factors
 
     def get_expectation_values(self) -> List[float]:

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -223,15 +223,15 @@ class Factory(ABC):
         self._options: Dict[str, Optional[float]] = {}
 
     def get_scale_factors(self) -> List[float]:
-        """Returns the scale factors that were either passed in to the facotry
+        """Returns the scale factors that were either passed in to the factory
         or at which the factory has computed expectation values.
         """
-        ret_scale_factors = [
+        scale_factors = [
             params.get("scale_factor", 0.0) for params in self._instack
         ]
-        if not ret_scale_factors and hasattr(self, "_scale_factors"):
+        if not scale_factors and hasattr(self, "_scale_factors"):
             return [scale_factor for scale_factor in self._scale_factors]
-        return ret_scale_factors
+        return scale_factors
 
     def get_expectation_values(self) -> List[float]:
         """Returns the expectation values computed by the factory."""

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -226,7 +226,14 @@ class Factory(ABC):
         """Returns the scale factors at which the factory has computed
         expectation values.
         """
-        return [params.get("scale_factor", 0.0) for params in self._instack]
+        ret_scale_factors = [
+            params.get("scale_factor", 0.0) for params in self._instack
+        ]
+        if not ret_scale_factors and hasattr(self, "_scale_factors"):
+            return [
+                float(scale_factor) for scale_factor in self._scale_factors
+            ]
+        return ret_scale_factors
 
     def get_expectation_values(self) -> List[float]:
         """Returns the expectation values computed by the factory."""

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -17,7 +17,7 @@ from pytest import mark, raises, warns
 
 from mitiq.zne.inference import (
     AdaExpFactory,
-    BatchedFactory,
+    AdaptiveFactory,
     ConvergenceWarning,
     ExpFactory,
     ExtrapolationError,
@@ -149,11 +149,11 @@ def test_get_scale_factors_static_factories(factory):
         fac = factory(scale_factors=scale_factors)
 
     # Expectation values haven't been computed at any scale factors yet
-    if isinstance(fac, BatchedFactory):
+    if isinstance(fac, AdaptiveFactory):
+        assert not fac.get_scale_factors()
+    else:
         assert isinstance(fac.get_scale_factors(), list)
         assert np.allclose(fac.get_scale_factors(), scale_factors)
-    else:
-        assert not fac.get_scale_factors()
 
     # Compute expectation values at all the scale factors
     fac.run_classical(apply_seed_to_func(f_lin, seed=1))

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -17,6 +17,7 @@ from pytest import mark, raises, warns
 
 from mitiq.zne.inference import (
     AdaExpFactory,
+    BatchedFactory,
     ConvergenceWarning,
     ExpFactory,
     ExtrapolationError,
@@ -148,7 +149,11 @@ def test_get_scale_factors_static_factories(factory):
         fac = factory(scale_factors=scale_factors)
 
     # Expectation values haven't been computed at any scale factors yet
-    assert not fac.get_scale_factors()
+    if isinstance(fac, BatchedFactory):
+        assert isinstance(fac.get_scale_factors(), list)
+        assert np.allclose(fac.get_scale_factors(), scale_factors)
+    else:
+        assert not fac.get_scale_factors()
 
     # Compute expectation values at all the scale factors
     fac.run_classical(apply_seed_to_func(f_lin, seed=1))


### PR DESCRIPTION
Fixes #2703 

## Description

Currently for static scale factors, the code requires a user either manually add scale factors to a factory using `push()` or to call `run` or `run_classical` in order for the factory's `instack` to be populated with the scale factors and therefore be returned when calling `get_scale_factors()`.

This is the case, even when the static scale factors are passed in when the factory is initialized. 

This PR address this by checking if the scale factors are not included in the factory's `instack`, but do exist as a property on the factory as `_scale_factors`. The property is populated when the factory is initialized and only applies to objects that are a subclass of `BatchedFactory`, like `PolyFactory`, `RichardsonFactory`, `FakeNodesFactory`, `LinearFactory`, `ExpFactory`, and `PolyExpFactory`.

If the factory's `instack` contain scale factors and the `_scale_factors` property is set, the values from the `instack` take priority and will be returned. 

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
