### PR TITLE
Lighter docs build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docs-clean:
 
 .PHONY: docs-lite
 docs-clean:
-	DOCS_LITE=1 make -C docs html
+	uv run DOCS_LITE=1 make -C docs html
 
 .PHONY: linkcheck
 linkcheck:

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ docs-clean:
 	uv run make -C docs clean
 	uv run make -C docs html
 
+.PHONY: docs-lite
+docs-clean:
+	DOCS_LITE=1 make -C docs html
+
 .PHONY: linkcheck
 linkcheck:
 	uv run make -C docs linkcheck

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ docs-clean:
 	uv run make -C docs html
 
 .PHONY: docs-lite
-docs-clean:
+docs-lite:
 	uv run DOCS_LITE=1 make -C docs html
 
 .PHONY: linkcheck

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docs-clean:
 
 .PHONY: docs-lite
 docs-lite:
-	uv run DOCS_LITE=1 make -C docs html
+	uv run env DOCS_LITE=1 make -C docs html
 
 .PHONY: linkcheck
 linkcheck:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -201,6 +201,9 @@ nb_execution_timeout = 600
 # By default, if nothing has changed in the source, a notebook won't be
 # re-run for a subsequent docs build.
 nb_execution_mode = "cache"
+if os.environ.get("DOCS_LITE"):
+    print("*** Skipping all notebook execution ***")
+    nb_execution_mode = "off"
 
 # If SKIP_PYQUIL is True, do not re-run PyQuil notebooks.
 if os.environ.get("SKIP_PYQUIL"):
@@ -411,6 +414,7 @@ myst_update_mathjax = False
 nbsphinx_custom_formats = {
     ".mystnb": ["jupytext.reads", {"fmt": "mystnb"}],
 }
+
 nbsphinx_execute = "always"
 
 nbsphinx_thumbnails = {


### PR DESCRIPTION
## Description

Adds a make target to build documentation without running any of the executable content. Just structure/markdown rendering.

fixes https://github.com/unitaryfoundation/mitiq/issues/2738 (maybe?)

