### PR TITLE
Update tutorials for IBM hardware

### DIFF
--- a/docs/source/examples/cdr_qrack.md
+++ b/docs/source/examples/cdr_qrack.md
@@ -48,7 +48,7 @@ from mitiq import cdr, Observable, PauliString
 
 import cirq
 
-from qiskit.providers.fake_provider import Fake5QV1
+from qiskit.providers.fake_provider import GenericBackendV2
 ```
 
 ## Sample Circuit
@@ -114,7 +114,7 @@ def qrack_simulate(circuit: cirq.Circuit, shots=1000) -> float:
 
 CDR requires the use of a quantum device or a noisy simulator. The near-Clifford circuits that are generated from the original circuit are executed on the quantum device or noisy simulator in order to compare against the simulated results.
 
-In this example, a Qiskit 5 Qubit Fake Backend is used. The `Fake5QV1` uses configurations and noise settings taken previously from the 5 qubit IBM Quantum Yorktown device. The `qiskit_noisy` function takes the Cirq circuit and uses Mitiq to change it into a Qiskit circuit. After adding measurements, the circuit is run on the fake backend. The expectation value for `00` is then returned.
+In this example, a Qiskit GenericBackendV2 is used. The [GenericBackendV2](https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.fake_provider.GenericBackendV2) uses configurations and default noise settings for gates and qubits. The `qiskit_noisy` function takes the Cirq circuit and uses Mitiq to change it into a Qiskit circuit. After adding measurements, the circuit is run on the fake backend. The expectation value for `00` is then returned.
 
 ```{code-cell}
 # Use Qiskit's Fave5QV1 as a noisy simulator
@@ -128,7 +128,7 @@ def qiskit_noisy(circuit: cirq.Circuit, shots=1000):
     qiskit_circ.measure_all()
 
     # Setup the fake backend and run the circuit
-    noisy_backend = Fake5QV1()
+    noisy_backend = GenericBackendV2(5)
     job = noisy_backend.run(qiskit_circ, shots=shots)
 
     # Use the resulting counts to return the expectation value of 00

--- a/docs/source/examples/cirq-ibmq-backends.md
+++ b/docs/source/examples/cirq-ibmq-backends.md
@@ -74,11 +74,12 @@ for instructions to create an account, save credentials, and see online quantum 
 ```{code-cell} ipython3
 import qiskit
 from qiskit_aer import QasmSimulator
-from qiskit_ibm_runtime import QiskitRuntimeService
+from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2 as Sampler
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from mitiq.interface.mitiq_qiskit.conversions import to_qiskit
 
 if QiskitRuntimeService.saved_accounts() and USE_REAL_HARDWARE:
-    service = QiskitRuntimeService()
+    service = QiskitRuntimeService(channel="ibm_quantum")
     backend = service.least_busy(operational=True, simulator=False)
     noise_model = False
 else:
@@ -99,18 +100,23 @@ def cirq_ibm_executor(cirq_circuit: cirq.Circuit, shots: int = 1024) -> float:
     circuit = to_qiskit(cirq_circuit) 
 
     # Transpile the circuit so it can be properly run
-    exec_circuit = qiskit.transpile(
-        circuit,
+    pm = generate_preset_pass_manager(
         backend=backend,
+        optimization_level=0,
         basis_gates=noise_model.basis_gates if noise_model else None,
-        optimization_level=0, # Important to preserve folded gates.
     )
+    exec_circuit = pm.run(circuit)
+
+    if not isinstance(exec_circuit, list):
+        exec_circuit = [exec_circuit]
+
+    sampler = Sampler(backend)
 
     # Run the circuit
-    job = backend.run(exec_circuit, shots=shots)
+    job = sampler.run(exec_circuit, shots=shots)
     
     # Convert from raw measurement counts to the expectation value
-    counts = job.result().get_counts()
+    counts = job.result()[0].join_data().get_counts()
     if counts.get("0") is None:
         expectation_value = 0.
     else:
@@ -192,15 +198,20 @@ Below we execute the folded circuits using the ``backend`` defined at the start 
 shots = 8192
 
 # Transpile the circuit so it can be properly run
-exec_circuit = qiskit.transpile(
-    folded_circuits,
+pm = generate_preset_pass_manager(
     backend=backend,
     basis_gates=noise_model.basis_gates if noise_model else None,
     optimization_level=0, # Important to preserve folded gates.
 )
 
+exec_circuit = pm.run(folded_circuits)
+
+if not isinstance(exec_circuit, list):
+    exec_circuit = [exec_circuit]
+
+sampler = Sampler(backend)
 # Run the circuit
-job = backend.run(exec_circuit, shots=shots)
+job = sampler.run(exec_circuit, shots=shots)
 ```
 
 **Note:** We set the ``optimization_level=0`` to prevent any compilation by Qiskit transpilers.
@@ -210,7 +221,7 @@ Once the job has finished executing, we can convert the raw measurement statisti
 following code block.
 
 ```{code-cell} ipython3
-all_counts = [job.result().get_counts(i) for i in range(len(folded_circuits))]
+all_counts = [job.result()[i].join_data().get_counts() for i in range(len(folded_circuits))]
 expectation_values = [counts.get("0") / shots for counts in all_counts]
 print(f"Expectation values:\n{expectation_values}")
 ```

--- a/docs/source/examples/ibmq-backends.md
+++ b/docs/source/examples/ibmq-backends.md
@@ -24,7 +24,8 @@ This tutorial shows an example of how to mitigate noise on IBMQ backends.
 ```{code-cell} ipython3
 import qiskit
 from qiskit_aer import QasmSimulator
-from qiskit_ibm_runtime import QiskitRuntimeService
+from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2 as Sampler
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from mitiq import zne
 from mitiq.interface.mitiq_qiskit.qiskit_utils import initialized_depolarizing_noise
@@ -74,7 +75,7 @@ for instructions to create an account, save credentials, and see online quantum 
 
 ```{code-cell} ipython3
 if QiskitRuntimeService.saved_accounts() and USE_REAL_HARDWARE:
-    service = QiskitRuntimeService()
+    service = QiskitRuntimeService(channel="ibm_quantum")
     backend = service.least_busy(operational=True, simulator=False)
     noise_model = False
 else:
@@ -92,18 +93,24 @@ def ibmq_executor(circuit: qiskit.QuantumCircuit, shots: int = 8192) -> float:
         shots: Number of times to execute the circuit to compute the expectation value.
     """
     # Transpile the circuit so it can be properly run
-    exec_circuit = qiskit.transpile(
-        circuit,
+    pm = generate_preset_pass_manager(
         backend=backend,
         basis_gates=noise_model.basis_gates if noise_model else None,
         optimization_level=0, # Important to preserve folded gates.
     )
-    
+
+    exec_circuit = pm.run(circuit)
+
+    if not isinstance(exec_circuit, list):
+        exec_circuit = [exec_circuit]
+
     # Run the circuit
-    job = backend.run(exec_circuit, shots=shots)
+    sampler = Sampler(backend)
+    
+    job = sampler.run(exec_circuit, shots=shots)
 
     # Convert from raw measurement counts to the expectation value
-    counts = job.result().get_counts()
+    counts = job.result()[0].join_data().get_counts()
     if counts.get("0") is None:
         expectation_value = 0.
     else:
@@ -186,15 +193,20 @@ Below we execute the folded circuits using the ``backend`` defined at the start 
 shots = 8192
 
 # Transpile the circuit so it can be properly run
-exec_circuit = qiskit.transpile(
-    folded_circuits,
+pm = generate_preset_pass_manager(
     backend=backend,
     basis_gates=noise_model.basis_gates if noise_model else None,
     optimization_level=0, # Important to preserve folded gates.
 )
+    
+exec_circuit = pm.run(folded_circuits)
+
+if not isinstance(exec_circuit, list):
+        exec_circuit = [exec_circuit]
 
 # Run the circuit
-job = backend.run(exec_circuit, shots=shots)
+sampler = Sampler(backend)
+job = sampler.run(exec_circuit, shots=shots)
 ```
 
 **Note:** We set the ``optimization_level=0`` to prevent any compilation by Qiskit transpilers.
@@ -202,6 +214,7 @@ job = backend.run(exec_circuit, shots=shots)
 
 Once the job has finished executing, we can convert the raw measurement statistics to observable values by running the
 following code block.
+<!-- #endregion -->
 
 ```{code-cell} ipython3
 all_counts = [job.result().get_counts(i) for i in range(len(folded_circuits))]

--- a/docs/source/examples/ibmq-backends.md
+++ b/docs/source/examples/ibmq-backends.md
@@ -217,7 +217,7 @@ following code block.
 <!-- #endregion -->
 
 ```{code-cell} ipython3
-all_counts = [job.result().get_counts(i) for i in range(len(folded_circuits))]
+all_counts = [job.result()[i].join_data().get_counts() for i in range(len(folded_circuits))]
 expectation_values = [counts.get("0") / shots for counts in all_counts]
 print(f"Expectation values:\n{expectation_values}")
 ```

--- a/docs/source/examples/pennylane-ibmq-backends.md
+++ b/docs/source/examples/pennylane-ibmq-backends.md
@@ -58,18 +58,23 @@ See <https://quantum-computing.ibm.com/> for instructions to create an account, 
 
 First, we get our devices set up depending on whether we would like to use real hardware, or a simulator.
 
+```{warning}
+This notebook may not run when `USE_REAL_HARDWARE = True` due to recent changes in Qiskit and Pennylane.
+We are working on mointoring and updating this in https://github.com/unitaryfoundation/mitiq/issues/2659.
+```
+
 ```{code-cell} ipython3
 import qiskit
-from qiskit_ibm_runtime import QiskitRuntimeService
+from qiskit_ibm_runtime import QiskitRuntimeService, SamplerV2 as Sampler
 
 USE_REAL_HARDWARE = False
 
-# TODO: Remove the below comment when PennyLane supports Qiskit 1.0
-# As of 03 May 2024, PennyLane is not compatible with Qiskit 1.0,
+# TODO: Remove the below comment when PennyLane supports Qiskit 1.3
+# As of May 19, 2025, PennyLane is not compatible with Qiskit 1.3,
 # but PennyLane plans to support the upgrade, soon
 if QiskitRuntimeService.saved_accounts() and USE_REAL_HARDWARE:
     service = QiskitRuntimeService()
-    backend = service.least_busy(operational=True, simulator=False)
+    backend = Sampler(service.least_busy(operational=True, simulator=False))
     dev = qml.device(
         "qiskit.ibmq",
         wires=1,


### PR DESCRIPTION
fixes #2711, fixes #2642, fixes #2634 

## Description
This PR addresses the migration away from backend.run() and the use of SamplerV2. Specifically, the following tutorials were addressed:

- [Error mitigation with Pennylane on IBMQ backends](https://mitiq.readthedocs.io/en/stable/examples/pennylane-ibmq-backends.html) - This has been updated with a warning (similar to what was mentioned in Nate's [comment](https://github.com/unitaryfoundation/mitiq/issues/2642#issuecomment-2891992655)) that using IBM hardware with PennyLane does not currently work. We are monitoring and updating this in the following [issue](https://github.com/unitaryfoundation/mitiq/issues/2659).

- [Use ZNE to simulate quantum many body scars with Qiskit on IBMQ backends](https://mitiq.readthedocs.io/en/stable/examples/quantum_simulation_scars_ibmq.html) - The code has been updated. This has also been tested successfully with IBM hardware.

- [Mitiq paper codeblocks](https://mitiq.readthedocs.io/en/stable/examples/mitiq-paper/mitiq-paper-codeblocks.html) - Code block 30 was updated. This has also been tested successfully with IBM hardware.

- [Error mitigation with Cirq on IBMQ backends](https://mitiq.readthedocs.io/en/stable/examples/cirq-ibmq-backends.html) - The code has been updated. This has also been tested successfully with IBM hardware.

- [Digital dynamical decoupling (DDD) with Qiskit on GHZ Circuits](https://mitiq.readthedocs.io/en/stable/examples/ddd_on_ibmq_ghz.html) - The code has been updated. This has also been tested successfully with IBM hardware.

- [Error mitigation on IBMQ backends with Qiskit](https://mitiq.readthedocs.io/en/stable/examples/ibmq-backends.html) - The code has been updated. This has also been tested successfully with IBM hardware.


- [CDR with Qrack as Near-Clifford Simulator](https://mitiq.readthedocs.io/en/stable/examples/cdr_qrack.html) - Unlike the tutorials above this code was not using real IBM hardware. Instead, it was using an old `Fake5QV1` backend which was updated to use `GenericBackendV2`. 

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
