### PR TITLE
refactor: migrate typing container types to collections.abc and built-in generics

### DIFF
--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -6,7 +6,8 @@
 """High-level digital dynamical decoupling (DDD) tools."""
 
 from functools import partial, wraps
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import numpy as np
 
@@ -20,10 +21,10 @@ def execute_with_ddd(
     observable: Optional[Observable] = None,
     *,
     rule: Callable[[int], QPROGRAM],
-    rule_args: Dict[str, Any] = {},
+    rule_args: dict[str, Any] = {},
     num_trials: int = 1,
     full_output: bool = False,
-) -> Union[float, Tuple[float, Dict[str, Any]]]:
+) -> Union[float, tuple[float, dict[str, Any]]]:
     r"""Estimates the error-mitigated expectation value associated to the
     input circuit, via the application of digital dynamical decoupling (DDD).
 
@@ -101,7 +102,7 @@ def combine_results(results: list[float]) -> float:
 def construct_circuits(
     circuit: QPROGRAM,
     rule: Callable[[int], QPROGRAM],
-    rule_args: Dict[str, Any] = {},
+    rule_args: dict[str, Any] = {},
     num_trials: int = 1,
 ) -> list[QPROGRAM]:
     """Generates a list of circuits with DDD sequences inserted.
@@ -134,10 +135,10 @@ def mitigate_executor(
     observable: Optional[Observable] = None,
     *,
     rule: Callable[[int], QPROGRAM],
-    rule_args: Dict[str, Any] = {},
+    rule_args: dict[str, Any] = {},
     num_trials: int = 1,
     full_output: bool = False,
-) -> Callable[[QPROGRAM], Union[float, Tuple[float, Dict[str, Any]]]]:
+) -> Callable[[QPROGRAM], Union[float, tuple[float, dict[str, Any]]]]:
     """Returns a modified version of the input 'executor' which is
     error-mitigated with digital dynamical decoupling (DDD).
 
@@ -169,7 +170,7 @@ def mitigate_executor(
         @wraps(executor)
         def new_executor(
             circuit: QPROGRAM,
-        ) -> Union[float, Tuple[float, Dict[str, Any]]]:
+        ) -> Union[float, tuple[float, dict[str, Any]]]:
             return execute_with_ddd(
                 circuit,
                 executor,
@@ -184,8 +185,8 @@ def mitigate_executor(
 
         @wraps(executor)
         def new_executor(
-            circuits: List[QPROGRAM],
-        ) -> List[Union[float, Tuple[float, Dict[str, Any]]]]:
+            circuits: list[QPROGRAM],
+        ) -> list[Union[float, tuple[float, dict[str, Any]]]]:
             return [
                 execute_with_ddd(
                     circuit,
@@ -206,12 +207,12 @@ def ddd_decorator(
     observable: Optional[Observable] = None,
     *,
     rule: Callable[[int], QPROGRAM],
-    rule_args: Dict[str, Any] = {},
+    rule_args: dict[str, Any] = {},
     num_trials: int = 1,
     full_output: bool = False,
 ) -> Callable[
     [Callable[[QPROGRAM], QuantumResult]],
-    Callable[[QPROGRAM], Union[float, Tuple[float, Dict[str, Any]]]],
+    Callable[[QPROGRAM], Union[float, tuple[float, dict[str, Any]]]],
 ]:
     """Decorator which adds an error-mitigation layer based on digital
     dynamical decoupling (DDD) to an executor function, i.e., a function which
@@ -241,7 +242,7 @@ def ddd_decorator(
 
     def decorator(
         executor: Callable[[QPROGRAM], QuantumResult],
-    ) -> Callable[[QPROGRAM], Union[float, Tuple[float, Dict[str, Any]]]]:
+    ) -> Callable[[QPROGRAM], Union[float, tuple[float, dict[str, Any]]]]:
         return mitigate_executor(
             executor,
             observable,

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -5,7 +5,7 @@
 
 """Tools to determine slack windows in circuits and to insert DDD sequences."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt

--- a/mitiq/ddd/rules/rules.py
+++ b/mitiq/ddd/rules/rules.py
@@ -8,7 +8,7 @@ slack window.
 """
 
 from itertools import cycle
-from typing import List
+from collections.abc import Sequence
 
 import numpy as np
 from cirq import (
@@ -24,7 +24,7 @@ from cirq import (
 
 
 def general_rule(
-    slack_length: int, gates: List[Gate], spacing: int = -1
+    slack_length: int, gates: Sequence[Gate], spacing: int = -1
 ) -> Circuit:
     """Returns a digital dynamical decoupling sequence, based on inputs.
 
@@ -147,7 +147,7 @@ def yy(slack_length: int, spacing: int = -1) -> Circuit:
     return yy_sequence
 
 
-def repeated_rule(slack_length: int, gates: List[Gate]) -> Circuit:
+def repeated_rule(slack_length: int, gates: Sequence[Gate]) -> Circuit:
     """Returns a general digital dynamical decoupling sequence that repeats
     until the slack is filled without spacing, up to a complete repetition.
 

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -6,7 +6,8 @@
 import copy
 from collections import defaultdict
 from numbers import Number
-from typing import Any, Callable, Iterable, List, Optional, Set, Union, cast
+from collections.abc import Iterable, Callable, Set
+from typing import Any, Optional, Union, cast
 
 import cirq
 import numpy as np
@@ -26,7 +27,7 @@ class Observable:
 
     def __init__(self, *paulis: PauliString) -> None:
         self._paulis = _combine_duplicate_pauli_strings(paulis)
-        self._groups: List[PauliStringCollection]
+        self._groups: list[PauliStringCollection]
         self._ngroups: int
         self.partition()
 
@@ -58,16 +59,16 @@ class Observable:
     def nterms(self) -> int:
         return len(self._paulis)
 
-    def _qubits(self) -> Set[cirq.Qid]:
+    def _qubits(self) -> set[cirq.Qid]:
         """Returns all qubits acted on by the Observable."""
         return {q for pauli in self._paulis for q in pauli._pauli.qubits}
 
     @property
-    def paulis(self) -> List[PauliString]:
+    def paulis(self) -> list[PauliString]:
         return self._paulis
 
     @property
-    def qubit_indices(self) -> List[int]:
+    def qubit_indices(self) -> list[int]:
         return [cast(cirq.LineQubit, q).x for q in sorted(self._qubits())]
 
     @property
@@ -95,7 +96,7 @@ class Observable:
         return NotImplemented
 
     @property
-    def groups(self) -> List[PauliStringCollection]:
+    def groups(self) -> list[PauliStringCollection]:
         return self._groups
 
     @property
@@ -118,8 +119,7 @@ class Observable:
                 behavior when partitioning.
         """
         rng = np.random.RandomState(seed)
-
-        psets: List[PauliStringCollection] = []
+        psets: list[PauliStringCollection] = []
         paulis = copy.deepcopy(self._paulis)
         rng.shuffle(paulis)  # type: ignore
 
@@ -138,7 +138,7 @@ class Observable:
         self._groups = psets
         self._ngroups = len(self._groups)
 
-    def measure_in(self, circuit: QPROGRAM) -> List[QPROGRAM]:
+    def measure_in(self, circuit: QPROGRAM) -> list[QPROGRAM]:
         """Given a quantum circuit, this method returns a list of circuits
         where each circuit corresponds to a different group of commuting Pauli
         strings, which allows measurement in the appropriate basis.
@@ -155,7 +155,7 @@ class Observable:
 
     def matrix(
         self,
-        qubit_indices: Optional[List[int]] = None,
+        qubit_indices: Optional[list[int]] = None,
     ) -> npt.NDArray[np.complex64]:
         """Returns the (potentially very large) matrix of the ``Observable``.
 
@@ -198,7 +198,7 @@ class Observable:
         return Executor(execute).evaluate(circuit, observable=self)[0]
 
     def _expectation_from_measurements(
-        self, measurements: List[MeasurementResult]
+        self, measurements: list[MeasurementResult]
     ) -> float:
         return sum(
             pset._expectation_from_measurements(bitstrings)
@@ -230,15 +230,13 @@ class Observable:
 
 def _combine_duplicate_pauli_strings(
     paulis: Iterable[PauliString],
-) -> List[PauliString]:
+) -> list[PauliString]:
     """Combines duplicate PauliStrings by adding their coefficients.
     Discards paulis with zero coefficients.
 
     Returns: deduped list of PauliStrings.
     """
-    pauli_string_coefficients: defaultdict[PauliString, complex] = defaultdict(
-        complex
-    )
+    pauli_string_coefficients: defaultdict[PauliString, complex] = defaultdict(complex)
     for pauli_string in paulis:
         cache_key = pauli_string.with_coeff(1)
         pauli_string_coefficients[cache_key] += pauli_string.coeff

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -5,8 +5,9 @@
 
 from collections import Counter
 from numbers import Number
-from typing import Any, Dict, List, Optional, Sequence, Set, Union, cast
-from typing import Counter as TCounter
+from collections.abc import Sequence, Set
+from typing import Any, Optional, Union, cast
+from collections import Counter as TCounter
 
 import cirq
 import numpy as np
@@ -82,7 +83,7 @@ class PauliString:
 
     def matrix(
         self,
-        qubit_indices_to_include: Optional[List[int]] = None,
+        qubit_indices_to_include: Optional[list[int]] = None,
     ) -> npt.NDArray[np.complex64]:
         """Returns the (potentially very large) matrix of the PauliString."""
         qubits = (
@@ -92,7 +93,7 @@ class PauliString:
         )
         return self._pauli.matrix(qubits=qubits)
 
-    def _basis_rotations(self) -> List[cirq.Operation]:
+    def _basis_rotations(self) -> list[cirq.Operation]:
         """Returns the basis rotations needed to measure the PauliString."""
         return [
             op
@@ -100,7 +101,7 @@ class PauliString:
             if op.gate != cirq.SingleQubitCliffordGate.I
         ]
 
-    def _qubits_to_measure(self) -> Set[cirq.Qid]:
+    def _qubits_to_measure(self) -> set[cirq.Qid]:
         return set(self._pauli.qubits)
 
     def measure_in(self, circuit: QPROGRAM) -> QPROGRAM:
@@ -134,7 +135,7 @@ class PauliString:
         the PauliString."""
         return _cirq_pauli_to_string(self._pauli)
 
-    def support(self) -> Set[int]:
+    def support(self) -> set[int]:
         return {q.x for q in self._pauli.qubits}
 
     def weight(self) -> int:
@@ -227,7 +228,7 @@ class PauliStringCollection:
                 self._paulis_by_weight[weight].update({pauli})
 
     @property
-    def elements(self) -> List[PauliString]:
+    def elements(self) -> list[PauliString]:
         return [
             pauli
             for paulis in self._paulis_by_weight.values()
@@ -235,10 +236,10 @@ class PauliStringCollection:
         ]
 
     @property
-    def elements_by_weight(self) -> Dict[int, TCounter[PauliString]]:
+    def elements_by_weight(self) -> dict[int, TCounter[PauliString]]:
         return self._paulis_by_weight
 
-    def support(self) -> Set[int]:
+    def support(self) -> set[int]:
         return {cast(cirq.LineQubit, q).x for q in self._qubits_to_measure()}
 
     def max_weight(self) -> int:

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -5,7 +5,8 @@
 
 import random
 from functools import singledispatch
-from typing import Callable, List, Optional
+from collections.abc import Callable
+from typing import Optional
 
 import cirq
 import pennylane as qml
@@ -71,7 +72,7 @@ def generate_pauli_twirl_variants(
     num_circuits: int = 10,
     noise_name: Optional[str] = None,
     **kwargs: float,
-) -> List[QPROGRAM]:
+) -> list[QPROGRAM]:
     r"""Return the Pauli twirled versions of the input circuit.
 
     Only the CNOT and CZ gates in an input circuit are Pauli twirled
@@ -161,7 +162,7 @@ def _pennylane(
     )
 
 
-def twirl_CNOT_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:
+def twirl_CNOT_gates(circuit: QPROGRAM, num_circuits: int) -> list[QPROGRAM]:
     """Generate a list of circuits using Pauli twirling on CNOT gates.
 
     Args:
@@ -176,7 +177,7 @@ def _twirl_CNOT_qprogram(circuit: cirq.Circuit) -> cirq.Circuit:
     return circuit.map_operations(_twirl_single_CNOT_gate)
 
 
-def twirl_CZ_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:
+def twirl_CZ_gates(circuit: QPROGRAM, num_circuits: int) -> list[QPROGRAM]:
     """Generate a list of circuits using Pauli twirling on CZ gates.
 
     Args:


### PR DESCRIPTION
- Replaced deprecated typing imports (List, Dict, Set, etc.) with built-in generics (list, dict, set, etc.) where possible
- Used collections.abc for abstract types (Iterable, Sequence, Callable, etc.)
- Modernized type hints for Python 3.9+ compatibility
- No functional changes, only type hint and import updates

Closes #<issue-if-any>

<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
