### PR TITLE
add `visualize_fits` to plot ZNE results with multiple extrapolation techniques

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ chrispy-chicken
 Jegbrz
 Kajetan Knopp
 lara-madison
+Inho Choi

--- a/mitiq/zne/__init__.py
+++ b/mitiq/zne/__init__.py
@@ -9,6 +9,7 @@ from mitiq.zne.zne import (
     zne_decorator,
     construct_circuits,
     combine_results,
+    visualize_fits,
 )
 from mitiq.zne import scaling
 from mitiq.zne.inference import (

--- a/mitiq/zne/zne.py
+++ b/mitiq/zne/zne.py
@@ -5,12 +5,41 @@
 
 """High-level zero-noise extrapolation tools."""
 
+import warnings
 from functools import wraps
-from typing import Callable, List, Optional, Sequence, Union
+from typing import (
+    Any,
+    Callable,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    Union,
+    cast,
+)
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.figure import Figure
 
 from mitiq import QPROGRAM, Executor, Observable, QuantumResult
-from mitiq.zne.inference import Factory, RichardsonFactory
+from mitiq.zne.inference import (
+    ExpFactory,
+    ExtrapolationError,
+    ExtrapolationResult,
+    Factory,
+    LinearFactory,
+    PolyFactory,
+    RichardsonFactory,
+)
 from mitiq.zne.scaling import fold_gates_at_random
+
+
+class SupportsExtrapolate(Protocol):
+    """Objects providing an ``extrapolate`` method."""
+
+    @staticmethod
+    def extrapolate(*args: Any, **kwargs: Any) -> ExtrapolationResult: ...
 
 
 def construct_circuits(
@@ -218,3 +247,126 @@ def zne_decorator(
         )
 
     return decorator
+
+
+def visualize_fits(
+    scale_factors: Sequence[float],
+    exp_values: Sequence[float],
+    *,
+    factories: Optional[Sequence[SupportsExtrapolate]] = None,
+    order: int = 2,
+) -> Figure:
+    """Visualizes extrapolation fits together with data.
+
+    Args:
+        scale_factors: Noise scale factors at which expectation values were
+            measured.
+        exp_values: Expectation values corresponding to ``scale_factors``.
+        factories: Sequence of objects implementing ``extrapolate``. If
+            ``None``, fits are produced by :class:`.LinearFactory`,
+            :class:`.PolyFactory` and :class:`.ExpFactory`.
+        order: Order for the default :class:`.PolyFactory`.
+            The polynomial fit requires at least ``order + 1`` data points,
+            while the exponential fit is only performed when more than three
+            points are provided.
+
+    Returns:
+        The matplotlib figure containing the data and fit curves.
+
+    Raises:
+        ValueError: If ``scale_factors`` and ``exp_values`` lengths do not
+            match.
+    """
+
+    if len(scale_factors) != len(exp_values):
+        raise ValueError(
+            "`scale_factors` and `exp_values` must have the same length."
+        )
+
+    if factories is None:
+        factories = [LinearFactory(scale_factors)]
+        if len(scale_factors) >= order + 1:
+            factories.append(PolyFactory(scale_factors, order))
+        else:
+            warnings.warn(
+                "Skipping PolyFactory: requires at least"
+                f" {order + 1} data points.",
+                UserWarning,
+            )
+        if len(scale_factors) > 3:
+            factories.append(ExpFactory(scale_factors))
+        else:
+            warnings.warn(
+                "Skipping ExpFactory: requires more than three data points.",
+                UserWarning,
+            )
+
+    fig = plt.figure(figsize=(7, 5))
+    ax = plt.gca()
+    ax.plot(
+        scale_factors,
+        exp_values,
+        "o",
+        markersize=10,
+        markeredgecolor="black",
+        alpha=0.8,
+        label=None,
+    )
+
+    smooth_scale_factors = np.linspace(0, max(scale_factors), 20)
+
+    for factory in factories:
+        try:
+            result = cast(
+                tuple[
+                    float,
+                    Optional[float],
+                    list[float],
+                    Optional[np.ndarray[Any, np.dtype[Any]]],
+                    Callable[[float], float],
+                ],
+                factory.extrapolate(
+                    scale_factors,
+                    exp_values,
+                    full_output=True,
+                    **getattr(factory, "_options", {}),
+                ),
+            )
+            curve = result[4]
+        except (ExtrapolationError, ValueError) as exc:
+            warnings.warn(
+                f"{factory.__class__.__name__} failed: {exc}",
+                UserWarning,
+            )
+            continue
+
+        if isinstance(factory, LinearFactory):
+            label = "Linear"
+        elif isinstance(factory, PolyFactory):
+            poly_order = getattr(factory, "_options", {}).get("order")
+            order_label = (
+                f" (order={poly_order})" if poly_order is not None else ""
+            )
+            label = f"Polynomial{order_label}"
+        elif isinstance(factory, ExpFactory):
+            label = "Exponential"
+        else:
+            label = getattr(
+                factory,
+                "method_label",
+                factory.__class__.__name__,
+            )
+        ax.plot(
+            smooth_scale_factors,
+            [curve(s) for s in smooth_scale_factors],
+            "--",
+            lw=2,
+            label=label,
+        )
+
+    plt.xlim(left=0)
+    ax.grid(True)
+    plt.xlabel("Noise scale factor")
+    plt.ylabel("Expectation value")
+    plt.legend()
+    return fig


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

This PR adds a plotting helper, `visualize_fits`, to the ZNE package.  
It allows users to visualize ZNE data with linear, polynomial (order configuratble), and exponential extrapolations.
This addition resolves issue #2624 by enabling visualization of ZNE results with multiple extrapolation techniques.



---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
