### PR TITLE
Calibrator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ chrispy-chicken
 Jegbrz
 Kajetan Knopp
 lara-madison
+Inho Choi

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -404,12 +404,12 @@ class Calibrator:
     def execute_with_mitigation(
         self,
         circuit: QPROGRAM,
-        executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
+        expval_executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
         observable: Optional[Observable] = None,
     ) -> Union[QuantumResult, None]:
         """See :func:`execute_with_mitigation` for signature and details."""
         return execute_with_mitigation(
-            circuit, executor, observable, calibrator=self
+            circuit, expval_executor, observable, calibrator=self
         )
 
 

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -496,3 +496,29 @@ def test_ExperimentResults_ensure_full():
     er = ExperimentResults(strategies, problems)
     with pytest.raises(MissingResultsError):
         er.ensure_full()
+
+
+def test_calibrator_custom_ideal_distribution():
+    q = cirq.LineQubit(0)
+    circ = cirq.Circuit(cirq.X(q))
+
+    settings = Settings(
+        benchmarks=[{"circuit_type": "custom", "circuit": circ}],
+        strategies=[
+            {
+                "technique": "zne",
+                "scale_noise": fold_global,
+                "factory": LinearFactory([1.0, 2.0]),
+            }
+        ],
+    )
+
+    ideal_exec = Executor(partial(damping_execute, noise_level=0))
+    cal = Calibrator(
+        damping_execute,
+        frontend="cirq",
+        settings=settings,
+        ideal_executor=ideal_exec,
+    )
+    problem = cal.problems[0]
+    assert problem.ideal_distribution == {"1": 1.0}

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -401,3 +401,33 @@ def test_num_circuits_required_raw_execution():
         technique_params={},
     )
     assert undefine_strategy.num_circuits_required() == 1
+
+
+def test_custom_circuit_problem():
+    q0, q1 = cirq.LineQubit.range(2)
+    circ = cirq.Circuit(cirq.H(q0), cirq.CNOT(q0, q1))
+    ideal = {"00": 0.5, "11": 0.5}
+
+    settings = Settings(
+        benchmarks=[
+            {
+                "circuit_type": "custom",
+                "circuit": circ,
+                "ideal_distribution": ideal,
+            }
+        ],
+        strategies=[
+            {
+                "technique": "zne",
+                "scale_noise": fold_global,
+                "factory": LinearFactory([1.0, 2.0]),
+            }
+        ],
+    )
+
+    problems = settings.make_problems()
+    assert len(problems) == 1
+    problem = problems[0]
+    assert problem.type == "custom"
+    assert problem.circuit == circ
+    assert problem.ideal_distribution == ideal


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

- Resolve Issue #2771 
- **Introduced support for user-specified circuits in calibration routines:**
   - The `Settings.make_problems` method now accepts "custom" circuits, converting user inputs to Mitiq circuits and defaulting the ideal distribution when necessar
- **Added an optional executor for ideal runs and populated ideal distributions for custom benchmarks:**
   - `Calibrator.__init__` builds an optional executor for ideal circuits and auto-populates ideal distributions for custom benchmarks when not supplied
   - A new `ideal_cirq_executor` property exposes that executor
- **Updated parameter name in execute_with_mitigation:**
   - `execute_with_mitigation` now takes a generic executor argument, mirroring the helper function’s signature
