### PR TITLE
refactor: migrate typing to collections.abc and built-in generics for containers (PEP 585)

### DIFF
--- a/mitiq/benchmarks/mirror_circuits.py
+++ b/mitiq/benchmarks/mirror_circuits.py
@@ -7,7 +7,7 @@
 :cite:`Proctor_2021_NatPhys` for benchmarking quantum computers
 (with error mitigation)."""
 
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import cirq
 import networkx as nx

--- a/mitiq/benchmarks/quantum_volume_circuits.py
+++ b/mitiq/benchmarks/quantum_volume_circuits.py
@@ -13,7 +13,8 @@ Cirq implementation of quantum volume circuits:
 cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
 """
 
-from typing import Optional, Sequence, Tuple
+from typing import Optional
+from collections.abc import Sequence
 
 from cirq import decompose as cirq_decompose
 from cirq.circuits import Circuit

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -10,7 +10,7 @@
 
 """Functions for generating randomized benchmarking circuits."""
 
-from typing import List, Optional
+from typing import Optional
 
 import cirq
 import numpy as np

--- a/mitiq/benchmarks/rotated_randomized_benchmarking.py
+++ b/mitiq/benchmarks/rotated_randomized_benchmarking.py
@@ -5,7 +5,7 @@
 
 """Functions for generating rotated randomized benchmarking circuits."""
 
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 import cirq
 import numpy as np

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -6,7 +6,8 @@
 """High-level digital dynamical decoupling (DDD) tools."""
 
 from functools import partial, wraps
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
+from collections.abc import Callable
 
 import numpy as np
 
@@ -20,10 +21,10 @@ def execute_with_ddd(
     observable: Optional[Observable] = None,
     *,
     rule: Callable[[int], QPROGRAM],
-    rule_args: Dict[str, Any] = {},
+    rule_args: dict[str, Any] = {},
     num_trials: int = 1,
     full_output: bool = False,
-) -> Union[float, Tuple[float, Dict[str, Any]]]:
+) -> Union[float, Tuple[float, dict[str, Any]]]:
     r"""Estimates the error-mitigated expectation value associated to the
     input circuit, via the application of digital dynamical decoupling (DDD).
 
@@ -101,7 +102,7 @@ def combine_results(results: list[float]) -> float:
 def construct_circuits(
     circuit: QPROGRAM,
     rule: Callable[[int], QPROGRAM],
-    rule_args: Dict[str, Any] = {},
+    rule_args: dict[str, Any] = {},
     num_trials: int = 1,
 ) -> list[QPROGRAM]:
     """Generates a list of circuits with DDD sequences inserted.
@@ -134,10 +135,10 @@ def mitigate_executor(
     observable: Optional[Observable] = None,
     *,
     rule: Callable[[int], QPROGRAM],
-    rule_args: Dict[str, Any] = {},
+    rule_args: dict[str, Any] = {},
     num_trials: int = 1,
     full_output: bool = False,
-) -> Callable[[QPROGRAM], Union[float, Tuple[float, Dict[str, Any]]]]:
+) -> Callable[[QPROGRAM], Union[float, Tuple[float, dict[str, Any]]]]:
     """Returns a modified version of the input 'executor' which is
     error-mitigated with digital dynamical decoupling (DDD).
 
@@ -184,8 +185,8 @@ def mitigate_executor(
 
         @wraps(executor)
         def new_executor(
-            circuits: List[QPROGRAM],
-        ) -> List[Union[float, Tuple[float, Dict[str, Any]]]]:
+            circuits: list[QPROGRAM],
+        ) -> list[Union[float, Tuple[float, dict[str, Any]]]]:
             return [
                 execute_with_ddd(
                     circuit,
@@ -206,12 +207,12 @@ def ddd_decorator(
     observable: Optional[Observable] = None,
     *,
     rule: Callable[[int], QPROGRAM],
-    rule_args: Dict[str, Any] = {},
+    rule_args: dict[str, Any] = {},
     num_trials: int = 1,
     full_output: bool = False,
 ) -> Callable[
     [Callable[[QPROGRAM], QuantumResult]],
-    Callable[[QPROGRAM], Union[float, Tuple[float, Dict[str, Any]]]],
+    Callable[[QPROGRAM], Union[float, Tuple[float, dict[str, Any]]]],
 ]:
     """Decorator which adds an error-mitigation layer based on digital
     dynamical decoupling (DDD) to an executor function, i.e., a function which

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -5,7 +5,7 @@
 
 """Tools to determine slack windows in circuits and to insert DDD sequences."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt

--- a/mitiq/ddd/rules/rules.py
+++ b/mitiq/ddd/rules/rules.py
@@ -8,7 +8,7 @@ slack window.
 """
 
 from itertools import cycle
-from typing import List
+from collections.abc import Sequence
 
 import numpy as np
 from cirq import (

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -5,7 +5,6 @@
 
 """Unit tests for high-level DDD tools."""
 
-from typing import List
 
 import cirq
 import numpy as np

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -6,7 +6,8 @@
 import copy
 from collections import defaultdict
 from numbers import Number
-from typing import Any, Callable, Iterable, List, Optional, Set, Union, cast
+from typing import Any, Callable, Optional, Union, cast
+from collections.abc import Iterable, Set, Callable
 
 import cirq
 import numpy as np
@@ -26,7 +27,7 @@ class Observable:
 
     def __init__(self, *paulis: PauliString) -> None:
         self._paulis = _combine_duplicate_pauli_strings(paulis)
-        self._groups: List[PauliStringCollection]
+        self._groups: list[PauliStringCollection]
         self._ngroups: int
         self.partition()
 
@@ -58,16 +59,16 @@ class Observable:
     def nterms(self) -> int:
         return len(self._paulis)
 
-    def _qubits(self) -> Set[cirq.Qid]:
+    def _qubits(self) -> set[cirq.Qid]:
         """Returns all qubits acted on by the Observable."""
         return {q for pauli in self._paulis for q in pauli._pauli.qubits}
 
     @property
-    def paulis(self) -> List[PauliString]:
+    def paulis(self) -> list[PauliString]:
         return self._paulis
 
     @property
-    def qubit_indices(self) -> List[int]:
+    def qubit_indices(self) -> list[int]:
         return [cast(cirq.LineQubit, q).x for q in sorted(self._qubits())]
 
     @property
@@ -95,7 +96,7 @@ class Observable:
         return NotImplemented
 
     @property
-    def groups(self) -> List[PauliStringCollection]:
+    def groups(self) -> list[PauliStringCollection]:
         return self._groups
 
     @property
@@ -119,7 +120,7 @@ class Observable:
         """
         rng = np.random.RandomState(seed)
 
-        psets: List[PauliStringCollection] = []
+        psets: list[PauliStringCollection] = []
         paulis = copy.deepcopy(self._paulis)
         rng.shuffle(paulis)  # type: ignore
 
@@ -138,7 +139,7 @@ class Observable:
         self._groups = psets
         self._ngroups = len(self._groups)
 
-    def measure_in(self, circuit: QPROGRAM) -> List[QPROGRAM]:
+    def measure_in(self, circuit: QPROGRAM) -> list[QPROGRAM]:
         """Given a quantum circuit, this method returns a list of circuits
         where each circuit corresponds to a different group of commuting Pauli
         strings, which allows measurement in the appropriate basis.
@@ -155,7 +156,7 @@ class Observable:
 
     def matrix(
         self,
-        qubit_indices: Optional[List[int]] = None,
+        qubit_indices: Optional[list[int]] = None,
     ) -> npt.NDArray[np.complex64]:
         """Returns the (potentially very large) matrix of the ``Observable``.
 
@@ -198,7 +199,7 @@ class Observable:
         return Executor(execute).evaluate(circuit, observable=self)[0]
 
     def _expectation_from_measurements(
-        self, measurements: List[MeasurementResult]
+        self, measurements: list[MeasurementResult]
     ) -> float:
         return sum(
             pset._expectation_from_measurements(bitstrings)
@@ -230,7 +231,7 @@ class Observable:
 
 def _combine_duplicate_pauli_strings(
     paulis: Iterable[PauliString],
-) -> List[PauliString]:
+) -> list[PauliString]:
     """Combines duplicate PauliStrings by adding their coefficients.
     Discards paulis with zero coefficients.
 

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -5,8 +5,11 @@
 
 from collections import Counter
 from numbers import Number
-from typing import Any, Dict, List, Optional, Sequence, Set, Union, cast
-from typing import Counter as TCounter
+from typing import Any, Optional, Union, cast
+from collections.abc import Sequence
+from collections.abc import Set
+from collections import Counter
+from collections.abc import Counter as TCounter
 
 import cirq
 import numpy as np
@@ -82,7 +85,7 @@ class PauliString:
 
     def matrix(
         self,
-        qubit_indices_to_include: Optional[List[int]] = None,
+        qubit_indices_to_include: Optional[list[int]] = None,
     ) -> npt.NDArray[np.complex64]:
         """Returns the (potentially very large) matrix of the PauliString."""
         qubits = (
@@ -92,7 +95,7 @@ class PauliString:
         )
         return self._pauli.matrix(qubits=qubits)
 
-    def _basis_rotations(self) -> List[cirq.Operation]:
+    def _basis_rotations(self) -> list[cirq.Operation]:
         """Returns the basis rotations needed to measure the PauliString."""
         return [
             op
@@ -206,7 +209,7 @@ class PauliStringCollection:
     def __init__(
         self, *paulis: PauliString, check_precondition: bool = True
     ) -> None:
-        self._paulis_by_weight: Dict[int, TCounter[PauliString]] = dict()
+        self._paulis_by_weight: dict[int, TCounter[PauliString]] = dict()
         self.add(*paulis, check_precondition=check_precondition)
 
     def can_add(self, pauli: PauliString) -> bool:
@@ -227,7 +230,7 @@ class PauliStringCollection:
                 self._paulis_by_weight[weight].update({pauli})
 
     @property
-    def elements(self) -> List[PauliString]:
+    def elements(self) -> list[PauliString]:
         return [
             pauli
             for paulis in self._paulis_by_weight.values()
@@ -235,10 +238,10 @@ class PauliStringCollection:
         ]
 
     @property
-    def elements_by_weight(self) -> Dict[int, TCounter[PauliString]]:
+    def elements_by_weight(self) -> dict[int, TCounter[PauliString]]:
         return self._paulis_by_weight
 
-    def support(self) -> Set[int]:
+    def support(self) -> set[int]:
         return {cast(cirq.LineQubit, q).x for q in self._qubits_to_measure()}
 
     def max_weight(self) -> int:
@@ -247,8 +250,8 @@ class PauliStringCollection:
     def min_weight(self) -> int:
         return min(self._paulis_by_weight.keys(), default=0)
 
-    def _qubits_to_measure(self) -> Set[cirq.Qid]:
-        qubits: Set[cirq.Qid] = set()
+    def _qubits_to_measure(self) -> set[cirq.Qid]:
+        qubits: set[cirq.Qid] = set()
         for pauli in self.elements:
             qubits.update(pauli._pauli.qubits)
         return qubits

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -5,7 +5,8 @@
 
 import random
 from functools import singledispatch
-from typing import Callable, List, Optional
+from typing import Optional
+from collections.abc import Callable
 
 import cirq
 import pennylane as qml

--- a/mitiq/qse/qse.py
+++ b/mitiq/qse/qse.py
@@ -7,7 +7,8 @@
 """High-level Quantum Susbapce Expansion tools."""
 
 from functools import wraps
-from typing import Callable, Dict, List, Sequence, Union
+from typing import Dict, Union
+from collections.abc import Callable, Sequence
 
 from mitiq import QPROGRAM, Executor, Observable, PauliString, QuantumResult
 from mitiq.qse.qse_utils import (

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -6,7 +6,8 @@
 """Functions for computing the projector for subspace expansion."""
 
 from itertools import product
-from typing import Callable, Dict, Optional, Sequence, Union
+from typing import Optional, Union
+from collections.abc import Callable, Sequence
 
 import numpy as np
 import numpy.typing as npt

--- a/mitiq/rem/inverse_confusion_matrix.py
+++ b/mitiq/rem/inverse_confusion_matrix.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from functools import reduce
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt

--- a/mitiq/rem/post_select.py
+++ b/mitiq/rem/post_select.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable
+from collections.abc import Callable
 
 from mitiq import Bitstring, MeasurementResult
 

--- a/mitiq/rem/rem.py
+++ b/mitiq/rem/rem.py
@@ -7,7 +7,8 @@
 
 from functools import wraps
 from types import MethodType
-from typing import Callable, List, Sequence, Union, cast
+from typing import Union, cast
+from collections.abc import Callable, Sequence
 
 import numpy as np
 import numpy.typing as npt

--- a/mitiq/rem/tests/test_rem.py
+++ b/mitiq/rem/tests/test_rem.py
@@ -6,7 +6,6 @@
 """Unit tests for readout confusion inversion."""
 
 from functools import partial
-from typing import List
 
 import cirq
 import numpy as np

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -17,17 +17,8 @@
 from collections import Counter
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Any, Dict, Optional, Tuple, Type, Union, cast
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt

--- a/mitiq/vd/vd.py
+++ b/mitiq/vd/vd.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable
+from collections.abc import Callable
 
 import cirq
 import numpy as np

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -3,7 +3,8 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional, Union, cast
+from typing import Optional, Union, cast
+from collections.abc import Sequence
 
 import cirq
 import numpy as np


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
