### PR TITLE
Sort qubits before measurement in calibrator

### DIFF
--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -292,7 +292,7 @@ class Calibrator:
             for problem in self.problems:
                 if problem.type == "custom" and not problem.ideal_distribution:
                     circ = problem.circuit.copy()
-                    circ.append(cirq.measure(circ.all_qubits()))
+                    circ.append(cirq.measure(sorted(circ.all_qubits())))
                     result = cast(
                         MeasurementResult,
                         self._ideal_cirq_executor.run([circ])[0],
@@ -434,7 +434,7 @@ def convert_to_expval_executor(executor: Executor, bitstring: str) -> Executor:
         circuit_with_meas = circuit.copy()
         if not cirq.is_measurement(circuit_with_meas):
             circuit_with_meas.append(
-                cirq.measure(circuit_with_meas.all_qubits())
+                cirq.measure(sorted(circuit_with_meas.all_qubits()))
             )
         raw = cast(MeasurementResult, executor.run([circuit_with_meas])[0])
         distribution = raw.prob_distribution()

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -351,7 +351,7 @@ class Calibrator:
         for problem in self.problems:
             # Benchmark circuits have no measurements, so we append them.
             circuit = problem.circuit.copy()
-            circuit.append(cirq.measure(circuit.all_qubits()))
+            circuit.append(cirq.measure(sorted(circuit.all_qubits())))
 
             bitstring_to_measure = problem.most_likely_bitstring()
             expval_executor = convert_to_expval_executor(


### PR DESCRIPTION
## Description

raised in https://github.com/unitaryfoundation/mitiq/discussions/2806

The `circuit.all_qubits` method returns a `frozenset` which is not guaranteed to have the same ordering each time. Differences in qubit ordering at the cirq level then propagate to other frontends (e.g. qiskit, as in the discussion post above) via the conversions. Here's an example:

```py
import cirq

from mitiq.interface.mitiq_qiskit import to_qiskit

q1, q2 = cirq.LineQubit.range(2)

circuit = cirq.Circuit(
    cirq.X(q1),
    cirq.Y(q2),
)
qubits = sorted(circuit.all_qubits())

# CASE 1: Measure in the order of qubits
circuit1 = circuit.copy()
circuit1.append(cirq.measure(qubits, key="m1"))

# CASE 2: Measure in reverse order
circuit2 = circuit.copy()
circuit2.append(cirq.measure(list(reversed(qubits)), key="m2"))

qiskit_circuit1 = to_qiskit(circuit1)
qiskit_circuit2 = to_qiskit(circuit2)

print("Qiskit circuit after 'normal' ordering:")
print(qiskit_circuit1)

print("Qiskit circuit after 'reversed' ordering:")
print(qiskit_circuit2)
```
**Output:**
```
Qiskit circuit from circuit1:
        ┌───┐┌─┐   
   q_0: ┤ X ├┤M├───
        ├───┤└╥┘┌─┐
   q_1: ┤ Y ├─╫─┤M├
        └───┘ ║ └╥┘
m_m1: 2/══════╩══╩═
              0  1 
Qiskit circuit from circuit2:
        ┌───┐   ┌─┐
   q_0: ┤ X ├───┤M├
        ├───┤┌─┐└╥┘
   q_1: ┤ Y ├┤M├─╫─
        └───┘└╥┘ ║ 
m_m2: 2/══════╩══╩═
              0  1 
```

Further, if you inspect the measurements from `circuit2` you'll find this:
```
CircuitInstruction(
    operation=Instruction(name='measure', num_qubits=1, num_clbits=1, params=[]),
    qubits=(Qubit(QuantumRegister(2, 'q'), 1),),          # 1st qubit
    clbits=(Clbit(ClassicalRegister(2, 'm_m2'), 0),)      # 0th classical bit
)
```