### PR TITLE
Fix typo in error message

### DIFF
--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -127,8 +127,8 @@ def convert_to_mitiq(circuit: QPROGRAM) -> tuple[cirq.Circuit, str]:
     else:
         raise UnsupportedCircuitError(
             f"Circuit from module {package} is not supported.\n\n"
-            f"Please register converters with register_mitiq_converters(),"
-            f"\n or specify a supported Circuit type:"
+            "Please register converters with register_mitiq_converters(),"
+            "\n or specify a supported Circuit type:"
             f"\n {SUPPORTED_PROGRAM_TYPES}"
         )
 
@@ -142,8 +142,8 @@ def convert_to_mitiq(circuit: QPROGRAM) -> tuple[cirq.Circuit, str]:
             "be supported, you can open an issue at "
             "https://github.com/unitaryfoundation/mitiq. \n\n Provided "
             f"circuit has type {type(circuit)} and is:\n\n{circuit}\n\n "
-            f"Circuit types supported by Mitiq are "
-            "\n{SUPPORTED_PROGRAM_TYPES}."
+            "Circuit types supported by Mitiq are "
+            f"\n{SUPPORTED_PROGRAM_TYPES}."
         )
 
     return mitiq_circuit, input_circuit_type


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

There was a small typo in some error message (missing the `f` for a f-string).

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code. (no new code)
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures. (no changes)
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions. (yes)
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant. (not relevant)
- [ ] Added myself / the copyright holder to the AUTHORS file (feel free to do so but I feel like it's a bit ridiculous for 3 characters)
