### PR TITLE
stop linkcheck failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,7 +312,7 @@ Fix packaging issue that caused `import mitiq` to fail due to missing VERSION.tx
 
 - Many tutorials are now updated with modern Qiskit code, ready to run on the latest IBM devices thanks to @bdg221!
 - A new tutorial demonstrating how to use [UCC](https://github.com/unitaryfoundation/ucc) in conjunction with Mitiq that shows how compilation and mitigation work well together.
-- The Virtual Distillation technique now has a complete [user guide](https://mitiq.readthedocs.io/en/stable/guide/vd.html) along with [API-docs](https://mitiq.readthedocs.io/en/stable/apidoc.html#mitiq.vd.vd.execute_with_vd).
+- The Virtual Distillation technique now has a complete [user guide](https://mitiq.readthedocs.io/en/stable/guide/vd.html) along with [API-docs](https://mitiq.readthedocs.io/en/stable/apidoc.html#mitiq.experimental.vd.vd.execute_with_vd).
 
 #### ✨ Enhancements
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -232,7 +232,10 @@ bibtex_bibfiles = ["refs.bib"]
 linkcheck_ignore = [
     r"https://arxiv\.org/.*",
     r"https://doi\.org/.*",
+    r"http://dx\.doi\.org/.*",
     r"https://link\.aps\.org/doi/.*",
+    r"https://journals\.aps\.org/.*",
+    r"https://.*pepy\.tech/.*",
     r"https://www\.sciencedirect\.com/science/article/.*",
     r"https://github.com/unitaryfoundation/mitiq/compare/.*",
     r"https://github.com/unitaryfoundation/mitiq/compare/.*",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -236,6 +236,7 @@ linkcheck_ignore = [
     r"https://link\.aps\.org/doi/.*",
     r"https://journals\.aps\.org/.*",
     r"https://.*pepy\.tech/.*",
+    r"https://www\.contributor-covenant\.org/.*",
     r"https://www\.sciencedirect\.com/science/article/.*",
     r"https://github.com/unitaryfoundation/mitiq/compare/.*",
     r"https://github.com/unitaryfoundation/mitiq/compare/.*",


### PR DESCRIPTION
## Description

The nightly docs build have been failing regularly due to linkcheck failures. That's not a good indicator of the docs build status. This PR should cut out that noise for links that should be permanent (journal links (that's their job) and pepy (I check this semi-regularly anyway)).

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.