### PR TITLE
python typing/formatting consistency

### DIFF
--- a/mitiq/interface/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -242,7 +242,7 @@ def _generate_random_program(n_qubits, length):
                 else:
                     param_val = random.uniform(-2 * pi, 2 * pi)
             else:
-                raise ValueError("Unknown gate parameter {}".format(param))
+                raise ValueError(f"Unknown gate parameter {param}")
 
             param_vals.append(param_val)
 

--- a/mitiq/pec/representations/tests/test_learning.py
+++ b/mitiq/pec/representations/tests/test_learning.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -249,10 +249,8 @@ def test_learn_depolarizing_noise_parameter(epsilon):
     epsilon0 = (1 - offset) * epsilon
     eps_string = str(epsilon).replace(".", "_")
     pec_data = np.loadtxt(
-        os.path.join(
-            "./mitiq/pec/representations/tests/learning_pec_data",
-            f"learning_pec_data_eps_{eps_string}.txt",
-        )
+        Path("./mitiq/pec/representations/tests/learning_pec_data")
+        / f"learning_pec_data_eps_{eps_string}.txt"
     )
 
     [success, epsilon_opt] = learn_depolarizing_noise_parameter(
@@ -304,10 +302,8 @@ def test_learn_biased_noise_parameters(epsilon, eta):
     eps_string = str(epsilon).replace(".", "_")
     for tc in range(0, num_training_circuits):
         pec_data[:, :, tc] = np.loadtxt(
-            os.path.join(
-                "./mitiq/pec/representations/tests/learning_pec_data",
-                f"learning_pec_data_eps_{eps_string}eta_{eta}tc_{tc}.txt",
-            )
+            Path("./mitiq/pec/representations/tests/learning_pec_data")
+            / f"learning_pec_data_eps_{eps_string}eta_{eta}tc_{tc}.txt"
         )
 
     [success, epsilon_opt, eta_opt] = learn_biased_noise_parameters(

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -18,7 +18,7 @@ from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
-from typing import Any, TypeAlias, Union, cast
+from typing import Any, TypeAlias, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -79,15 +79,15 @@ except ImportError:  # pragma: no cover
     _OpenQASMCircuit = _Circuit  # type: ignore
 
 # Supported + installed quantum programs.
-QPROGRAM = Union[
-    _Circuit,
-    _Program,
-    _QuantumCircuit,
-    _BKCircuit,
-    _QuantumTape,
-    _QiboCircuit,
-    _OpenQASMCircuit,
-]
+QPROGRAM: TypeAlias = (
+    _Circuit
+    | _Program
+    | _QuantumCircuit
+    | _BKCircuit
+    | _QuantumTape
+    | _QiboCircuit
+    | _OpenQASMCircuit
+)
 
 
 # Supported quantum programs.

--- a/mitiq/zne/scaling/parameter.py
+++ b/mitiq/zne/scaling/parameter.py
@@ -37,8 +37,8 @@ def _get_base_gate(gate: EigenGate) -> EigenGate:
         if isinstance(gate, base_gate):
             return cast(EigenGate, base_gate)
     raise GateTypeException(
-        "Must have circuit be made of rotation gates. "
-        "Your gate {} may not be supported".format(gate)
+        f"Must have circuit be made of rotation gates. "
+        f"Your gate {gate} may not be supported"
     )
 
 

--- a/mitiq/zne/viz.py
+++ b/mitiq/zne/viz.py
@@ -128,7 +128,7 @@ def visualize_fits(
             result = cast(
                 tuple[
                     float,
-                    Optional[float],
+                    float | None,
                     list[float],
                     npt.NDArray[Any] | None,
                     Callable[[float], float],

--- a/mitiq/zne/viz.py
+++ b/mitiq/zne/viz.py
@@ -6,7 +6,7 @@
 """Visualization utilities for zero-noise extrapolation."""
 
 import warnings
-from typing import Any, Callable, Optional, Protocol, Sequence, cast
+from typing import Any, Callable, Protocol, Sequence, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -34,9 +34,9 @@ def visualize_fits(
     scale_factors: Sequence[float],
     exp_values: Sequence[float],
     *,
-    factories: Optional[Sequence[SupportsExtrapolate]] = None,
+    factories: Sequence[SupportsExtrapolate] | None = None,
     order: int = 2,
-    ideal_value: Optional[float] = None,
+    ideal_value: float | None = None,
 ) -> Figure:
     """Visualizes extrapolation fits together with data.
 


### PR DESCRIPTION
## Description

Does what it says on the 🥫.

1. f-string over `.format`
2. `pathlib` over `os`
3. `|` over `Union`/`Optional`