### PR TITLE
revert typing change on `QPROGRAM`

### DIFF
--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -18,7 +18,7 @@ from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
-from typing import Any, TypeAlias, cast
+from typing import Any, TypeAlias, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -79,15 +79,15 @@ except ImportError:  # pragma: no cover
     _OpenQASMCircuit = _Circuit  # type: ignore
 
 # Supported + installed quantum programs.
-QPROGRAM: TypeAlias = (
-    _Circuit
-    | _Program
-    | _QuantumCircuit
-    | _BKCircuit
-    | _QuantumTape
-    | _QiboCircuit
-    | _OpenQASMCircuit
-)
+QPROGRAM: TypeAlias = Union[
+    _Circuit,
+    _Program,
+    _QuantumCircuit,
+    _BKCircuit,
+    _QuantumTape,
+    _QiboCircuit,
+    _OpenQASMCircuit,
+]
 
 
 # Supported quantum programs.


### PR DESCRIPTION
## Description

The docs build was failing with:
```
TypeError: unsupported operand type(s) for |: 'ABCMeta' and 'Program'
```
This is caused by the changes I introduced in https://github.com/unitaryfoundation/mitiq/pull/3019 as the `A | B` syntax causes `type(A).__or__(A, B)` to run at runtime (resulting in the error above). `Union` avoids this since there is no runtime call and does not depend on the metaclasses of `A` and `B.