### PR TITLE
Fix TREX combine_results qubit indexing for partial-support observables

### DIFF
--- a/mitiq/experimental/trex/tests/test_trex.py
+++ b/mitiq/experimental/trex/tests/test_trex.py
@@ -129,6 +129,38 @@ def test_trex_single_qubit():
     assert np.isclose(result, -1.0, atol=0.1)
 
 
+@pytest.mark.parametrize(
+    "spec, expected",
+    [
+        ("ZII", -1.0),
+        ("IZI", -1.0),
+        ("IIZ", -1.0),
+        ("ZZZ", -1.0),
+    ],
+)
+def test_trex_observable_on_subset_of_qubits(spec, expected):
+    """TREX must be correct when the observable acts on only a subset of the
+    circuit's qubits, including high-index qubits.
+
+    Regression test: ``combine_results`` previously indexed the randomization
+    string by ``sorted(observable._qubits())`` instead of by the circuit's
+    qubits, so the readout twirling was undone with the wrong bits whenever the
+    observable did not act on qubit 0, silently corrupting the result.
+    """
+    qreg = [cirq.LineQubit(i) for i in range(3)]
+    circuit = cirq.Circuit(cirq.X.on_each(*qreg))  # prepares |111>
+    obs = Observable(PauliString(spec))
+
+    result = execute_with_trex(
+        circuit,
+        noiseless_executor,
+        obs,
+        num_randomizations=16,
+        random_state=0,
+    )
+    assert np.isclose(result, expected, atol=0.1)
+
+
 def test_trex_identity_circuit():
     """TREX on an identity circuit should give expectation +1 for Z."""
     q = cirq.LineQubit(0)

--- a/mitiq/experimental/trex/tests/test_trex.py
+++ b/mitiq/experimental/trex/tests/test_trex.py
@@ -161,6 +161,22 @@ def test_trex_observable_on_subset_of_qubits(spec, expected):
     assert np.isclose(result, expected, atol=0.1)
 
 
+def test_trex_observable_on_noncontiguous_circuit_qubits():
+    qreg = [cirq.LineQubit(i) for i in (0, 2, 4)]
+    circuit = cirq.Circuit(cirq.X.on_each(*qreg))
+    # Position 2 in the canonical ordering targets LineQubit(4).
+    obs = Observable(PauliString("Z", support=(2,)))
+
+    result = execute_with_trex(
+        circuit,
+        noiseless_executor,
+        obs,
+        num_randomizations=16,
+        random_state=0,
+    )
+    assert np.isclose(result, -1.0, atol=0.1)
+
+
 def test_trex_identity_circuit():
     """TREX on an identity circuit should give expectation +1 for Z."""
     q = cirq.LineQubit(0)

--- a/mitiq/experimental/trex/trex.py
+++ b/mitiq/experimental/trex/trex.py
@@ -227,8 +227,25 @@ def combine_results(
         raise ValueError(
             "At least one randomization string is required for TREX."
         )
-    all_qubits = sorted(observable._qubits())
-    qubit_to_idx = {q: i for i, q in enumerate(all_qubits)}
+
+    # The randomization strings are indexed by the *circuit's* qubits (the
+    # order in which ``construct_circuits`` applied the twirling), which is
+    # exactly the set of qubits measured by the calibration circuits. Recover
+    # that ordering from the calibration results so the randomization string is
+    # indexed consistently with how the twirling was applied. Indexing by
+    # ``observable._qubits()`` would be incorrect whenever the observable acts
+    # on only a subset of the circuit's qubits (e.g. a single-qubit Pauli on a
+    # high-index qubit), silently corrupting the mitigated value.
+    calibration_qubit_indices = calibration_results[0].qubit_indices
+    if calibration_qubit_indices is None:
+        calibration_qubit_indices = tuple(
+            range(calibration_results[0].nqubits)
+        )
+    circuit_qubit_indices = list(calibration_qubit_indices)
+    qubit_to_idx = {
+        q: circuit_qubit_indices.index(cast(cirq.LineQubit, q).x)
+        for q in observable._qubits()
+    }
 
     total: complex = 0.0
     for group_idx, group in enumerate(observable.groups):

--- a/mitiq/experimental/trex/trex.py
+++ b/mitiq/experimental/trex/trex.py
@@ -163,7 +163,7 @@ def construct_circuits(
     group_qubits = []
     for group in observable.groups:
         meas_cirq = cast(cirq.Circuit, group.measure_in(cirq_circuit))
-        measured_qubits = sorted(group._qubits_to_measure())
+        measured_qubits = [all_qubits[i] for i in sorted(group.support())]
         measurement_circuits.append(meas_cirq)
         group_qubits.append(measured_qubits)
 
@@ -228,28 +228,11 @@ def combine_results(
             "At least one randomization string is required for TREX."
         )
 
-    # The randomization strings are indexed by the *circuit's* qubits (the
-    # order in which ``construct_circuits`` applied the twirling), which is
-    # exactly the set of qubits measured by the calibration circuits. Recover
-    # that ordering from the calibration results so the randomization string is
-    # indexed consistently with how the twirling was applied. Indexing by
-    # ``observable._qubits()`` would be incorrect whenever the observable acts
-    # on only a subset of the circuit's qubits (e.g. a single-qubit Pauli on a
-    # high-index qubit), silently corrupting the mitigated value.
-    calibration_qubit_indices = calibration_results[0].qubit_indices
-    if calibration_qubit_indices is None:
-        calibration_qubit_indices = tuple(
-            range(calibration_results[0].nqubits)
-        )
-    circuit_qubit_indices = list(calibration_qubit_indices)
-    qubit_to_idx = {
-        q: circuit_qubit_indices.index(cast(cirq.LineQubit, q).x)
-        for q in observable._qubits()
-    }
-
     total: complex = 0.0
     for group_idx, group in enumerate(observable.groups):
-        measured_qubits = sorted(group._qubits_to_measure())
+        # Observable support uses canonical positions in the circuit's sorted
+        # qubit order, which is also how randomization strings are indexed.
+        measured_qubit_indices = sorted(group.support())
 
         for pauli in group.elements:
             support = sorted(pauli.support())
@@ -262,7 +245,7 @@ def combine_results(
 
                 # XOR with the randomization bits for measured qubits.
                 s_group = np.array(
-                    [s[qubit_to_idx[q]] for q in measured_qubits],
+                    [s[i] for i in measured_qubit_indices],
                     dtype=np.int64,
                 )
                 flipped_twirled = xor_bitstrings(twirled_res, s_group)
@@ -277,8 +260,10 @@ def combine_results(
                 # XOR calibration with full randomization string.
                 flipped_calib = xor_bitstrings(calib_res, s)
 
-                # Compute calibration parity on same support qubits.
-                calib_bits = flipped_calib.filter_qubits(support)
+                # Calibration results measure every circuit qubit in the same
+                # order as the randomization strings. Select support by its
+                # canonical circuit position, not by physical qubit label.
+                calib_bits = flipped_calib.asarray[:, support]
                 calib_factor = float(
                     np.mean([(-1) ** np.sum(b) for b in calib_bits])
                 )


### PR DESCRIPTION
combine_results indexed the randomization string using qubit_to_idx built from sorted(observable._qubits()), but the randomization strings are generated in construct_circuits indexed by the circuit's qubits. When the observable does not act on every circuit qubit (e.g. a single-qubit Pauli on a high-index qubit), the readout twirling was undone with the wrong bits, silently producing an incorrect mitigated value.

Derive the circuit's qubit ordering from the calibration results (which measure all circuit qubits in the same order the randomization string is indexed) so the twirl is undone consistently. This needs no public API change.

Add a parametrized regression test covering observables acting on qubits 0, 1, 2 and all three qubits of a 3-qubit |111> state; the qubit-1 and qubit-2 cases fail on main without this fix.

<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

`combine_results` in `mitiq.experimental.trex` builds its `qubit_to_idx` map
from `sorted(observable._qubits())`, but the randomization strings produced by
`construct_circuits` are indexed by the **circuit's** qubits. When an
observable does not act on every circuit qubit (e.g. a single-qubit Pauli on a
high-index qubit), the readout twirling is undone with the wrong bits and TREX
silently returns an incorrect expectation value.

## Reproduction (on `main`)
A noiseless 3-qubit `|111⟩` circuit, expectation of single-qubit `Z`:
- `Z` on qubit 0 → `-1.0` ✅
- `Z` on qubit 1 → `+0.125` ❌ (should be `-1.0`)
- `Z` on qubit 2 → `+0.25`  ❌ (should be `-1.0`)

## Fix
Recover the circuit's qubit ordering from the calibration results (which
measure all circuit qubits in the same order the randomization string is
indexed) and index `s` consistently. No public API change.

## Tests
Adds a parametrized regression test (`test_trex_observable_on_subset_of_qubits`)
covering `Z` on qubits 0/1/2 and `ZZZ`. The qubit‑1 and qubit‑2 cases fail on
`main` without this change. Full `trex` suite passes (44 tests); `ruff` and
`mypy` clean.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
