### PR TITLE
Add optional return_info when inserting DDD sequences

### DIFF
--- a/docs/source/guide/ddd-1-intro.md
+++ b/docs/source/guide/ddd-1-intro.md
@@ -123,6 +123,7 @@ In this section we demonstrate the use of {func}`.ddd.construct_circuits` for th
 ### Generating circuits with DDD sequences
 
 Here we will generate a list of circuits with DDD sequences inserted, which will later be passed to the executor. The number of circuits generated can be checked using the `len` function.
+Each trial is also logged at INFO on ``mitiq.ddd`` (idle windows found and sequences inserted).
 
 ```{code-cell} ipython3
 circuits_with_ddd = ddd.construct_circuits(circuit=circuit, rule=rule, num_trials=10)

--- a/docs/source/guide/ddd-4-low-level.md
+++ b/docs/source/guide/ddd-4-low-level.md
@@ -122,6 +122,24 @@ circuit_with_ddd = ddd.insert_ddd_sequences(circuit, rule=xyxy_rule)
 circuit_with_ddd
 ```
 
+### Checking whether DDD sequences were inserted
+
+By default, {func}`.insert_ddd_sequences()` returns only the modified circuit.
+If the input has no sufficiently long idle windows, DDD may leave the circuit unchanged.
+To inspect what happened without changing the default API, pass ``return_info=True``:
+
+```{code-cell} ipython3
+circuit_with_ddd, ddd_info = ddd.insert_ddd_sequences(
+    circuit, rule=xyxy_rule, return_info=True
+)
+print(ddd_info.num_idle_windows)
+print(ddd_info.num_sequences_inserted)
+print(ddd_info.idle_window_lengths)
+```
+
+The returned {class}`~mitiq.ddd.insertion.DDDInfo` reports how many idle windows were found,
+how many non-empty DDD sequences were inserted, and the length of each candidate window.
+
 ```{note}
 In principle, the function {func}`.insert_ddd_sequences()` is all one needs to apply DDD.
 Indeed, since in DDD there is not a final post-processing step, one can simply insert DDD sequences before running the circuit on a noisy backend.

--- a/docs/source/guide/ddd-4-low-level.md
+++ b/docs/source/guide/ddd-4-low-level.md
@@ -140,6 +140,14 @@ print(ddd_info.idle_window_lengths)
 The returned {class}`~mitiq.ddd.insertion.DDDInfo` reports how many idle windows were found,
 how many non-empty DDD sequences were inserted, and the length of each candidate window.
 
+{func}`.ddd.construct_circuits` logs the same counts at INFO on the ``mitiq.ddd`` logger
+(one line per trial). Enable it with:
+
+```{code-block} python
+import logging
+logging.getLogger("mitiq.ddd").setLevel(logging.INFO)
+```
+
 ```{note}
 In principle, the function {func}`.insert_ddd_sequences()` is all one needs to apply DDD.
 Indeed, since in DDD there is not a final post-processing step, one can simply insert DDD sequences before running the circuit on a noisy backend.

--- a/mitiq/ddd/__init__.py
+++ b/mitiq/ddd/__init__.py
@@ -10,6 +10,7 @@ from mitiq.ddd import rules
 from mitiq.ddd import insertion
 
 from mitiq.ddd.insertion import (
+    DDDInfo,
     get_slack_matrix_from_circuit_mask,
     insert_ddd_sequences,
 )

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -7,7 +7,7 @@
 
 from collections.abc import Callable
 from functools import partial, wraps
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 
@@ -143,9 +143,8 @@ def construct_circuits(
     circuits_with_ddd: list[QPROGRAM] = []
     ddd_infos: list[DDDInfo] = []
     for _ in range(num_trials):
-        circuit_with_ddd, info = cast(
-            tuple[QPROGRAM, DDDInfo],
-            insert_ddd_sequences(circuit, rule_partial, return_info=True),
+        circuit_with_ddd, info = insert_ddd_sequences(
+            circuit, rule_partial, return_info=True
         )
         circuits_with_ddd.append(circuit_with_ddd)
         ddd_infos.append(info)

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -5,14 +5,17 @@
 
 """High-level digital dynamical decoupling (DDD) tools."""
 
+import logging
 from collections.abc import Callable
 from functools import partial, wraps
-from typing import Any
+from typing import Any, Literal, overload
 
 import numpy as np
 
 from mitiq import QPROGRAM, Executor, Observable, QuantumResult
 from mitiq.ddd.insertion import DDDInfo, insert_ddd_sequences
+
+LOGGER = logging.getLogger("mitiq.ddd")
 
 
 def execute_with_ddd(
@@ -101,6 +104,46 @@ def combine_results(results: list[float]) -> float:
     return float(np.average(results))
 
 
+def _log_ddd_info(info: DDDInfo, *, trial: int, num_trials: int) -> None:
+    """Log idle-window / insertion counts for one DDD trial."""
+    if num_trials == 1:
+        LOGGER.info(
+            "DDD: found %s idle windows; inserted %s sequences",
+            info.num_idle_windows,
+            info.num_sequences_inserted,
+        )
+        return
+    LOGGER.info(
+        "DDD trial %s/%s: found %s idle windows; inserted %s sequences",
+        trial,
+        num_trials,
+        info.num_idle_windows,
+        info.num_sequences_inserted,
+    )
+
+
+@overload
+def construct_circuits(
+    circuit: QPROGRAM,
+    rule: Callable[[int], QPROGRAM],
+    rule_args: dict[str, Any] | None = None,
+    num_trials: int = 1,
+    *,
+    return_info: Literal[False] = False,
+) -> list[QPROGRAM]: ...
+
+
+@overload
+def construct_circuits(
+    circuit: QPROGRAM,
+    rule: Callable[[int], QPROGRAM],
+    rule_args: dict[str, Any] | None = None,
+    num_trials: int = 1,
+    *,
+    return_info: Literal[True],
+) -> tuple[list[QPROGRAM], tuple[DDDInfo, ...]]: ...
+
+
 def construct_circuits(
     circuit: QPROGRAM,
     rule: Callable[[int], QPROGRAM],
@@ -108,8 +151,13 @@ def construct_circuits(
     num_trials: int = 1,
     *,
     return_info: bool = False,
-) -> list[QPROGRAM] | tuple[list[QPROGRAM], list[DDDInfo]]:
+) -> list[QPROGRAM] | tuple[list[QPROGRAM], tuple[DDDInfo, ...]]:
     """Generates a list of circuits with DDD sequences inserted.
+
+    Each trial is logged at INFO on the ``mitiq.ddd`` logger (idle windows
+    found and sequences inserted). Logging is silent unless that logger is
+    enabled; ``insert_ddd_sequences`` does not log, so there is no duplicate
+    output when this function calls it.
 
     Args:
         circuit: The quantum circuit to be modified with DD.
@@ -121,7 +169,7 @@ def construct_circuits(
         num_trials: The number of circuits to generate with DDD insertions.
         return_info: If ``False`` (default), return only the list of
             circuits. If ``True``, return a tuple ``(circuits_with_ddd,
-            ddd_infos)`` where ``ddd_infos`` has one
+            ddd_infos)`` where ``ddd_infos`` is a tuple of one
             :class:`~mitiq.ddd.insertion.DDDInfo` per trial.
 
     Returns:
@@ -133,23 +181,19 @@ def construct_circuits(
     rule_partial: Callable[[int], QPROGRAM]
     rule_partial = partial(rule, **rule_args)
 
-    # Insert DDD sequences in (a copy of) the input circuit
-    if not return_info:
-        return [
-            insert_ddd_sequences(circuit, rule_partial)
-            for _ in range(num_trials)
-        ]
-
     circuits_with_ddd: list[QPROGRAM] = []
     ddd_infos: list[DDDInfo] = []
-    for _ in range(num_trials):
+    for trial in range(1, num_trials + 1):
         circuit_with_ddd, info = insert_ddd_sequences(
             circuit, rule_partial, return_info=True
         )
         circuits_with_ddd.append(circuit_with_ddd)
         ddd_infos.append(info)
+        _log_ddd_info(info, trial=trial, num_trials=num_trials)
 
-    return circuits_with_ddd, ddd_infos
+    if return_info:
+        return circuits_with_ddd, tuple(ddd_infos)
+    return circuits_with_ddd
 
 
 def mitigate_executor(

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -12,7 +12,7 @@ from typing import Any
 import numpy as np
 
 from mitiq import QPROGRAM, Executor, Observable, QuantumResult
-from mitiq.ddd.insertion import insert_ddd_sequences
+from mitiq.ddd.insertion import DDDInfo, insert_ddd_sequences
 
 
 def execute_with_ddd(
@@ -106,7 +106,9 @@ def construct_circuits(
     rule: Callable[[int], QPROGRAM],
     rule_args: dict[str, Any] | None = None,
     num_trials: int = 1,
-) -> list[QPROGRAM]:
+    *,
+    return_info: bool = False,
+) -> list[QPROGRAM] | tuple[list[QPROGRAM], list[DDDInfo]]:
     """Generates a list of circuits with DDD sequences inserted.
 
     Args:
@@ -117,9 +119,14 @@ def construct_circuits(
             applied in that window.
         rule_args: An optional dictionary of keyword arguments for ``rule``.
         num_trials: The number of circuits to generate with DDD insertions.
+        return_info: If ``False`` (default), return only the list of
+            circuits. If ``True``, return a tuple ``(circuits_with_ddd,
+            ddd_infos)`` where ``ddd_infos`` has one
+            :class:`~mitiq.ddd.insertion.DDDInfo` per trial.
 
     Returns:
-        A list of circuits with DDD inserted.
+        A list of circuits with DDD inserted, or ``(circuits_with_ddd,
+        ddd_infos)`` if ``return_info`` is ``True``.
     """
     if rule_args is None:
         rule_args = {}
@@ -127,11 +134,22 @@ def construct_circuits(
     rule_partial = partial(rule, **rule_args)
 
     # Insert DDD sequences in (a copy of) the input circuit
-    circuits_with_ddd = [
-        insert_ddd_sequences(circuit, rule_partial) for _ in range(num_trials)
-    ]
+    if not return_info:
+        return [
+            insert_ddd_sequences(circuit, rule_partial)
+            for _ in range(num_trials)
+        ]
 
-    return circuits_with_ddd
+    circuits_with_ddd = []
+    ddd_infos = []
+    for _ in range(num_trials):
+        circuit_with_ddd, info = insert_ddd_sequences(
+            circuit, rule_partial, return_info=True
+        )
+        circuits_with_ddd.append(circuit_with_ddd)
+        ddd_infos.append(info)
+
+    return circuits_with_ddd, ddd_infos
 
 
 def mitigate_executor(

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -7,7 +7,7 @@
 
 from collections.abc import Callable
 from functools import partial, wraps
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -140,11 +140,12 @@ def construct_circuits(
             for _ in range(num_trials)
         ]
 
-    circuits_with_ddd = []
-    ddd_infos = []
+    circuits_with_ddd: list[QPROGRAM] = []
+    ddd_infos: list[DDDInfo] = []
     for _ in range(num_trials):
-        circuit_with_ddd, info = insert_ddd_sequences(
-            circuit, rule_partial, return_info=True
+        circuit_with_ddd, info = cast(
+            tuple[QPROGRAM, DDDInfo],
+            insert_ddd_sequences(circuit, rule_partial, return_info=True),
         )
         circuits_with_ddd.append(circuit_with_ddd)
         ddd_infos.append(info)

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -211,12 +211,15 @@ def _insert_ddd_sequences_with_info(
 ) -> tuple[QPROGRAM, DDDInfo]:
     """Insert DDD sequences and return both the converted circuit and info.
 
-    ``@accept_qprogram_and_validate`` only supports Cirq→Cirq (or one-to-many)
-    returns, so it cannot propagate :class:`DDDInfo` on its own. We apply that
-    decorator to a one-shot circuit transformer that records info via a local
-    nonlocal binding, then return a normal ``(circuit, info)`` tuple. No
-    mutable out-parameter is part of any function signature.
+    Cirq inputs go straight through :func:`_apply_ddd_sequences`, which returns
+    a normal ``(circuit, DDDInfo)`` tuple. Other frontends still need
+    ``@accept_qprogram_and_validate`` for conversion, and that decorator can
+    only return a ``QPROGRAM``, so info is recorded in a local binding and
+    returned as a normal tuple. No caller-facing out-parameter.
     """
+    if isinstance(circuit, Circuit):
+        return _apply_ddd_sequences(circuit, rule)
+
     info: DDDInfo | None = None
 
     def _insert_and_record(circ: Circuit) -> Circuit:
@@ -227,7 +230,6 @@ def _insert_ddd_sequences_with_info(
     circuit_with_ddd = accept_qprogram_and_validate(_insert_and_record)(
         circuit
     )
-    # _insert_and_record always assigns info before returning.
     assert info is not None
     return circuit_with_ddd, info
 

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -6,6 +6,7 @@
 """Tools to determine slack windows in circuits and to insert DDD sequences."""
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import cirq
 import numpy as np
@@ -15,6 +16,23 @@ from cirq import Circuit, I, LineQubit, synchronize_terminal_measurements
 from mitiq import QPROGRAM
 from mitiq.interface import accept_qprogram_and_validate
 from mitiq.interface.conversions import convert_to_mitiq
+
+
+@dataclass(frozen=True)
+class DDDInfo:
+    """Structured information about a DDD insertion pass.
+
+    Attributes:
+        num_idle_windows: Number of single-qubit idle windows with slack length
+            greater than 1 (candidates for DDD insertion).
+        num_sequences_inserted: Number of non-empty DDD sequences that were
+            inserted into those windows.
+        idle_window_lengths: Length of each candidate idle window, in moments.
+    """
+
+    num_idle_windows: int
+    num_sequences_inserted: int
+    idle_window_lengths: tuple[int, ...]
 
 
 def _get_circuit_mask(circuit: Circuit) -> npt.NDArray[np.int64]:
@@ -91,7 +109,9 @@ def get_slack_matrix_from_circuit_mask(
 def insert_ddd_sequences(
     circuit: QPROGRAM,
     rule: Callable[[int], QPROGRAM],
-) -> QPROGRAM:
+    *,
+    return_info: bool = False,
+) -> QPROGRAM | tuple[QPROGRAM, DDDInfo]:
     """Returns the circuit with DDD sequences applied according to the input
     rule.
 
@@ -100,18 +120,32 @@ def insert_ddd_sequences(
         rule: The rule determining what DDD sequences should be applied.
             A set of built-in DDD rules can be imported from
             ``mitiq.ddd.rules``.
+        return_info: If ``False`` (default), return only the circuit with
+            DDD sequences added. If ``True``, return a tuple
+            ``(circuit_with_ddd, ddd_info)`` where ``ddd_info`` is a
+            :class:`~mitiq.ddd.insertion.DDDInfo` describing idle windows
+            found and sequences inserted. This is useful for verifying
+            that DDD actually modified the circuit (e.g. when there are
+            no idle windows).
 
     Returns:
-        The circuit with DDD sequences added.
+        The circuit with DDD sequences added, or
+        ``(circuit_with_ddd, ddd_info)`` if ``return_info`` is ``True``.
     """
-
-    return _insert_ddd_sequences(circuit, rule)
+    info_out: list[DDDInfo] = []
+    circuit_with_ddd = _insert_ddd_sequences(
+        circuit, rule, _info_out=info_out if return_info else None
+    )
+    if return_info:
+        return circuit_with_ddd, info_out[0]
+    return circuit_with_ddd
 
 
 @accept_qprogram_and_validate
 def _insert_ddd_sequences(
     circuit: Circuit,
     rule: Callable[[int], QPROGRAM],
+    _info_out: list[DDDInfo] | None = None,
 ) -> Circuit:
     """Returns the circuit with DDD sequences applied according to the input
     rule.
@@ -121,6 +155,11 @@ def _insert_ddd_sequences(
         rule: The rule determining what DDD sequences should be applied.
             A set of built-in DDD rules can be imported from
             ``mitiq.ddd.rules``.
+        _info_out: Optional mutable list used as an out-parameter. When
+            provided, a single :class:`DDDInfo` is appended after insertion.
+            This keeps the public return type of the decorated function a
+            circuit so ``accept_qprogram_and_validate`` conversion is
+            unchanged.
 
     Returns:
         The circuit with DDD sequences added.
@@ -146,14 +185,20 @@ def _insert_ddd_sequences(
     # Copy to avoid mutating the input circuit
     circuit_with_ddd = circuit.copy()
     qubits = sorted(circuit.all_qubits())
+    idle_window_lengths: list[int] = []
+    num_sequences_inserted = 0
     for moment_idx in range(len(circuit)):
         slack_column = slack_matrix[:, moment_idx]
         for row_index, slack_length in enumerate(slack_column):
             if slack_length > 1:
+                idle_window_lengths.append(int(slack_length))
                 ddd_sequence = cirq_rule(slack_length).transform_qubits(
                     {LineQubit(0): qubits[row_index]}
                 )
-                for idx, op in enumerate(ddd_sequence.all_operations()):
+                operations = list(ddd_sequence.all_operations())
+                if operations:
+                    num_sequences_inserted += 1
+                for idx, op in enumerate(operations):
                     moment = circuit_with_ddd[moment_idx + idx]
                     op_to_replace = moment.operation_at(*op.qubits)
 
@@ -163,4 +208,13 @@ def _insert_ddd_sequences(
                     circuit_with_ddd[moment_idx + idx] = moment.with_operation(
                         op
                     )
+
+    if _info_out is not None:
+        _info_out.append(
+            DDDInfo(
+                num_idle_windows=len(idle_window_lengths),
+                num_sequences_inserted=num_sequences_inserted,
+                idle_window_lengths=tuple(idle_window_lengths),
+            )
+        )
     return circuit_with_ddd

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -114,8 +114,8 @@ def _apply_ddd_sequences(
     """Insert DDD sequences into a Cirq circuit.
 
     Always returns ``(circuit_with_ddd, info)``. This is the single Cirq-level
-    implementation; conversion wrappers either discard ``info`` or thread it
-    out as a proper return value (never via a mutable out-parameter).
+    implementation; conversion wrappers either discard ``info`` or pass it
+    through as an extra return value.
 
     Args:
         circuit: The Cirq circuit to be modified with DDD sequences.
@@ -211,27 +211,13 @@ def _insert_ddd_sequences_with_info(
 ) -> tuple[QPROGRAM, DDDInfo]:
     """Insert DDD sequences and return both the converted circuit and info.
 
-    Cirq inputs go straight through :func:`_apply_ddd_sequences`, which returns
-    a normal ``(circuit, DDDInfo)`` tuple. Other frontends still need
-    ``@accept_qprogram_and_validate`` for conversion, and that decorator can
-    only return a ``QPROGRAM``, so info is recorded in a local binding and
-    returned as a normal tuple. No caller-facing out-parameter.
+    :func:`_apply_ddd_sequences` always returns ``(circuit, DDDInfo)``.
+    ``accept_qprogram_and_validate(..., returns_extra=True)`` converts the
+    circuit and passes the info through as a normal extra return value.
     """
-    if isinstance(circuit, Circuit):
-        return _apply_ddd_sequences(circuit, rule)
-
-    info: DDDInfo | None = None
-
-    def _insert_and_record(circ: Circuit) -> Circuit:
-        nonlocal info
-        circuit_with_ddd, info = _apply_ddd_sequences(circ, rule)
-        return circuit_with_ddd
-
-    circuit_with_ddd = accept_qprogram_and_validate(_insert_and_record)(
-        circuit
-    )
-    assert info is not None
-    return circuit_with_ddd, info
+    return accept_qprogram_and_validate(
+        _apply_ddd_sequences, returns_extra=True
+    )(circuit, rule)
 
 
 @overload

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -7,6 +7,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal, overload
 
 import cirq
 import numpy as np
@@ -106,63 +107,24 @@ def get_slack_matrix_from_circuit_mask(
     return slack_matrix
 
 
-def insert_ddd_sequences(
-    circuit: QPROGRAM,
-    rule: Callable[[int], QPROGRAM],
-    *,
-    return_info: bool = False,
-) -> QPROGRAM | tuple[QPROGRAM, DDDInfo]:
-    """Returns the circuit with DDD sequences applied according to the input
-    rule.
-
-    Args:
-        circuit: The QPROGRAM circuit to be modified with DDD sequences.
-        rule: The rule determining what DDD sequences should be applied.
-            A set of built-in DDD rules can be imported from
-            ``mitiq.ddd.rules``.
-        return_info: If ``False`` (default), return only the circuit with
-            DDD sequences added. If ``True``, return a tuple
-            ``(circuit_with_ddd, ddd_info)`` where ``ddd_info`` is a
-            :class:`~mitiq.ddd.insertion.DDDInfo` describing idle windows
-            found and sequences inserted. This is useful for verifying
-            that DDD actually modified the circuit (e.g. when there are
-            no idle windows).
-
-    Returns:
-        The circuit with DDD sequences added, or
-        ``(circuit_with_ddd, ddd_info)`` if ``return_info`` is ``True``.
-    """
-    info_out: list[DDDInfo] = []
-    circuit_with_ddd = _insert_ddd_sequences(
-        circuit, rule, _info_out=info_out if return_info else None
-    )
-    if return_info:
-        return circuit_with_ddd, info_out[0]
-    return circuit_with_ddd
-
-
-@accept_qprogram_and_validate
-def _insert_ddd_sequences(
+def _apply_ddd_sequences(
     circuit: Circuit,
     rule: Callable[[int], QPROGRAM],
-    _info_out: list[DDDInfo] | None = None,
-) -> Circuit:
-    """Returns the circuit with DDD sequences applied according to the input
-    rule.
+) -> tuple[Circuit, DDDInfo]:
+    """Insert DDD sequences into a Cirq circuit.
+
+    Always returns ``(circuit_with_ddd, info)``. This is the single Cirq-level
+    implementation; conversion wrappers either discard ``info`` or thread it
+    out as a proper return value (never via a mutable out-parameter).
 
     Args:
         circuit: The Cirq circuit to be modified with DDD sequences.
         rule: The rule determining what DDD sequences should be applied.
             A set of built-in DDD rules can be imported from
             ``mitiq.ddd.rules``.
-        _info_out: Optional mutable list used as an out-parameter. When
-            provided, a single :class:`DDDInfo` is appended after insertion.
-            This keeps the public return type of the decorated function a
-            circuit so ``accept_qprogram_and_validate`` conversion is
-            unchanged.
 
     Returns:
-        The circuit with DDD sequences added.
+        A tuple ``(circuit_with_ddd, ddd_info)``.
     """
     circuit = synchronize_terminal_measurements(circuit)
     if not circuit.are_all_measurements_terminal():
@@ -209,12 +171,111 @@ def _insert_ddd_sequences(
                         op
                     )
 
-    if _info_out is not None:
-        _info_out.append(
-            DDDInfo(
-                num_idle_windows=len(idle_window_lengths),
-                num_sequences_inserted=num_sequences_inserted,
-                idle_window_lengths=tuple(idle_window_lengths),
-            )
-        )
+    info = DDDInfo(
+        num_idle_windows=len(idle_window_lengths),
+        num_sequences_inserted=num_sequences_inserted,
+        idle_window_lengths=tuple(idle_window_lengths),
+    )
+    return circuit_with_ddd, info
+
+
+@accept_qprogram_and_validate
+def _insert_ddd_sequences(
+    circuit: Circuit,
+    rule: Callable[[int], QPROGRAM],
+) -> Circuit:
+    """Returns the circuit with DDD sequences applied according to the input
+    rule.
+
+    Circuit-only wrapper for :func:`_apply_ddd_sequences`. The decorator
+    requires a Cirq→Cirq return type so frontend conversion stays unchanged;
+    callers that need :class:`DDDInfo` go through
+    :func:`insert_ddd_sequences` with ``return_info=True``.
+
+    Args:
+        circuit: The Cirq circuit to be modified with DDD sequences.
+        rule: The rule determining what DDD sequences should be applied.
+            A set of built-in DDD rules can be imported from
+            ``mitiq.ddd.rules``.
+
+    Returns:
+        The circuit with DDD sequences added.
+    """
+    circuit_with_ddd, _ = _apply_ddd_sequences(circuit, rule)
     return circuit_with_ddd
+
+
+def _insert_ddd_sequences_with_info(
+    circuit: QPROGRAM,
+    rule: Callable[[int], QPROGRAM],
+) -> tuple[QPROGRAM, DDDInfo]:
+    """Insert DDD sequences and return both the converted circuit and info.
+
+    ``@accept_qprogram_and_validate`` only supports Cirq→Cirq (or one-to-many)
+    returns, so it cannot propagate :class:`DDDInfo` on its own. We apply that
+    decorator to a one-shot circuit transformer that records info via a local
+    nonlocal binding, then return a normal ``(circuit, info)`` tuple. No
+    mutable out-parameter is part of any function signature.
+    """
+    info: DDDInfo | None = None
+
+    def _insert_and_record(circ: Circuit) -> Circuit:
+        nonlocal info
+        circuit_with_ddd, info = _apply_ddd_sequences(circ, rule)
+        return circuit_with_ddd
+
+    circuit_with_ddd = accept_qprogram_and_validate(_insert_and_record)(
+        circuit
+    )
+    # _insert_and_record always assigns info before returning.
+    assert info is not None
+    return circuit_with_ddd, info
+
+
+@overload
+def insert_ddd_sequences(
+    circuit: QPROGRAM,
+    rule: Callable[[int], QPROGRAM],
+    *,
+    return_info: Literal[False] = False,
+) -> QPROGRAM: ...
+
+
+@overload
+def insert_ddd_sequences(
+    circuit: QPROGRAM,
+    rule: Callable[[int], QPROGRAM],
+    *,
+    return_info: Literal[True],
+) -> tuple[QPROGRAM, DDDInfo]: ...
+
+
+def insert_ddd_sequences(
+    circuit: QPROGRAM,
+    rule: Callable[[int], QPROGRAM],
+    *,
+    return_info: bool = False,
+) -> QPROGRAM | tuple[QPROGRAM, DDDInfo]:
+    """Returns the circuit with DDD sequences applied according to the input
+    rule.
+
+    Args:
+        circuit: The QPROGRAM circuit to be modified with DDD sequences.
+        rule: The rule determining what DDD sequences should be applied.
+            A set of built-in DDD rules can be imported from
+            ``mitiq.ddd.rules``.
+        return_info: If ``False`` (default), return only the circuit with
+            DDD sequences added. If ``True``, return a tuple
+            ``(circuit_with_ddd, ddd_info)`` where ``ddd_info`` is a
+            :class:`~mitiq.ddd.insertion.DDDInfo` describing idle windows
+            found and sequences inserted. This is useful for verifying
+            that DDD actually modified the circuit (e.g. when there are
+            no idle windows).
+
+    Returns:
+        The circuit with DDD sequences added, or
+        ``(circuit_with_ddd, ddd_info)`` if ``return_info`` is ``True``.
+    """
+    if return_info:
+        return _insert_ddd_sequences_with_info(circuit, rule)
+    return _insert_ddd_sequences(circuit, rule)

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -11,6 +11,7 @@ from pytest import mark
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES, Executor
 from mitiq.ddd import (
+    DDDInfo,
     construct_circuits,
     ddd_decorator,
     execute_with_ddd,
@@ -240,3 +241,24 @@ def test_num_trials_generates_circuits(num_trials: int):
     )
 
     assert num_trials == len(circuits)
+
+
+def test_construct_circuits_return_info_default_is_list_only():
+    """Default API remains a plain list of circuits (no tuple)."""
+    circuits = construct_circuits(circuit_cirq_a, rule=xx, num_trials=3)
+    assert isinstance(circuits, list)
+    assert all(isinstance(c, QPROGRAM) for c in circuits)
+
+
+def test_construct_circuits_return_info_true():
+    """Optional return_info reports one DDDInfo per trial."""
+    circuits, infos = construct_circuits(
+        circuit_cirq_a, rule=xx, num_trials=3, return_info=True
+    )
+
+    assert len(circuits) == 3
+    assert len(infos) == 3
+    assert all(isinstance(info, DDDInfo) for info in infos)
+    assert circuits == construct_circuits(
+        circuit_cirq_a, rule=xx, num_trials=3
+    )

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -5,6 +5,9 @@
 
 """Unit tests for high-level DDD tools."""
 
+import inspect
+import logging
+
 import cirq
 import numpy as np
 from pytest import mark
@@ -15,6 +18,7 @@ from mitiq.ddd import (
     construct_circuits,
     ddd_decorator,
     execute_with_ddd,
+    insert_ddd_sequences,
     mitigate_executor,
 )
 from mitiq.ddd.rules import xx, xyxy, yy
@@ -258,7 +262,78 @@ def test_construct_circuits_return_info_true():
 
     assert len(circuits) == 3
     assert len(infos) == 3
+    assert isinstance(infos, tuple)
     assert all(isinstance(info, DDDInfo) for info in infos)
     assert circuits == construct_circuits(
         circuit_cirq_a, rule=xx, num_trials=3
     )
+
+
+def test_construct_circuits_and_insert_have_no_mutable_defaults():
+    """Public kwargs use None/immutable defaults, not a shared list/dict."""
+    for func in (construct_circuits, insert_ddd_sequences, execute_with_ddd):
+        for param in inspect.signature(func).parameters.values():
+            default = param.default
+            if default is inspect.Parameter.empty:
+                continue
+            assert not isinstance(default, (list, dict, set)), param.name
+
+
+def test_construct_circuits_return_info_not_shared_across_calls():
+    """Tuple info from one call must not leak into the next."""
+    q = cirq.LineQubit(0)
+    empty = cirq.Circuit(cirq.H(q), cirq.X(q), cirq.H(q))
+    idle = cirq.Circuit(cirq.H(q), cirq.I(q), cirq.I(q), cirq.H(q))
+
+    _, infos_empty = construct_circuits(empty, rule=xx, return_info=True)
+    _, infos_idle = construct_circuits(idle, rule=xx, return_info=True)
+    _, infos_empty_again = construct_circuits(empty, rule=xx, return_info=True)
+
+    assert infos_empty[0].num_idle_windows == 0
+    assert infos_idle[0].num_idle_windows == 1
+    assert infos_empty_again[0].num_idle_windows == 0
+    assert infos_idle[0].idle_window_lengths == (2,)
+
+
+def test_construct_circuits_logs_insertion(caplog):
+    """INFO logging on mitiq.ddd reports idle windows and insertions."""
+    caplog.set_level(logging.INFO, logger="mitiq.ddd")
+    construct_circuits(circuit_cirq_a, rule=xx, num_trials=1)
+
+    assert "idle windows" in caplog.text
+    assert "inserted" in caplog.text
+    assert "sequences" in caplog.text
+
+
+def test_construct_circuits_logs_each_trial(caplog):
+    """Multiple trials log one line each, not a single combined message."""
+    caplog.set_level(logging.INFO, logger="mitiq.ddd")
+    construct_circuits(circuit_cirq_a, rule=xx, num_trials=3)
+
+    trial_records = [
+        rec
+        for rec in caplog.records
+        if rec.name == "mitiq.ddd" and "DDD trial" in rec.getMessage()
+    ]
+    assert len(trial_records) == 3
+    assert "1/3" in trial_records[0].getMessage()
+    assert "3/3" in trial_records[2].getMessage()
+
+
+def test_construct_circuits_logs_when_nothing_inserted(caplog):
+    """Logging still reports zeros when DDD finds no idle windows."""
+    caplog.set_level(logging.INFO, logger="mitiq.ddd")
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.H(q), cirq.X(q), cirq.H(q))
+    construct_circuits(circuit, rule=xx)
+
+    assert "found 0 idle windows; inserted 0 sequences" in caplog.text
+
+
+def test_insert_ddd_sequences_does_not_log(caplog):
+    """Logging lives on construct_circuits only (no duplicate noise)."""
+    caplog.set_level(logging.INFO, logger="mitiq.ddd")
+    insert_ddd_sequences(circuit_cirq_a, rule=xx)
+    insert_ddd_sequences(circuit_cirq_a, rule=xx, return_info=True)
+
+    assert caplog.records == []

--- a/mitiq/ddd/tests/test_insertion.py
+++ b/mitiq/ddd/tests/test_insertion.py
@@ -5,6 +5,8 @@
 
 """Unit tests for DDD slack windows and DDD insertion tools."""
 
+import inspect
+
 import cirq
 import numpy as np
 import pyquil
@@ -391,6 +393,34 @@ def test_insert_ddd_sequences_return_info_empty_rule():
     assert info.num_idle_windows == 2
     assert info.num_sequences_inserted == 0
     assert info.idle_window_lengths == (2, 2)
+
+
+def test_insert_ddd_sequences_return_info_not_shared_across_calls():
+    """Successive return_info calls do not share mutable state."""
+    q = cirq.LineQubit(0)
+    empty = cirq.Circuit(cirq.H(q), cirq.X(q), cirq.H(q))
+    idle = cirq.Circuit(cirq.H(q), cirq.I(q), cirq.I(q), cirq.H(q))
+
+    _, info_empty = insert_ddd_sequences(empty, rule=xx, return_info=True)
+    _, info_idle = insert_ddd_sequences(idle, rule=xx, return_info=True)
+    _, info_empty_again = insert_ddd_sequences(
+        empty, rule=xx, return_info=True
+    )
+
+    assert info_empty.num_idle_windows == 0
+    assert info_idle.num_idle_windows == 1
+    assert info_empty_again.num_idle_windows == 0
+    assert info_idle.idle_window_lengths == (2,)
+    assert info_empty.idle_window_lengths == ()
+
+
+def test_insert_ddd_sequences_has_no_mutable_defaults():
+    """No shared list/dict default on the public insertion API."""
+    for param in inspect.signature(insert_ddd_sequences).parameters.values():
+        default = param.default
+        if default is inspect.Parameter.empty:
+            continue
+        assert not isinstance(default, (list, dict, set)), param.name
 
 
 def test_insert_ddd_sequences_return_info_qiskit():

--- a/mitiq/ddd/tests/test_insertion.py
+++ b/mitiq/ddd/tests/test_insertion.py
@@ -12,6 +12,7 @@ import pytest
 import qiskit
 
 from mitiq.ddd.insertion import (
+    DDDInfo,
     _get_circuit_mask,
     get_slack_matrix_from_circuit_mask,
     insert_ddd_sequences,
@@ -317,3 +318,95 @@ def test_insert_sequences_with_qiskit_rule():
 
     result = insert_ddd_sequences(circuit, rule=qiskit_xx)
     assert result == expected
+
+
+def test_insert_ddd_sequences_return_info_default_is_circuit_only():
+    """Default API remains circuit-only (no tuple)."""
+    qubits = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.ops.H.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.H.on_each(*qubits),
+    )
+    result = insert_ddd_sequences(circuit, rule=xx)
+    assert isinstance(result, cirq.Circuit)
+    assert not isinstance(result, tuple)
+
+
+def test_insert_ddd_sequences_return_info_true():
+    """Optional return_info reports idle windows and insertions."""
+    qubits = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.ops.H.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.H.on_each(*qubits),
+    )
+    circuit_with_ddd, info = insert_ddd_sequences(
+        circuit, rule=xx, return_info=True
+    )
+
+    assert isinstance(circuit_with_ddd, cirq.Circuit)
+    assert isinstance(info, DDDInfo)
+    assert info.num_idle_windows == 2
+    assert info.num_sequences_inserted == 2
+    assert info.idle_window_lengths == (2, 2)
+    assert circuit_with_ddd == insert_ddd_sequences(circuit, rule=xx)
+
+
+def test_insert_ddd_sequences_return_info_no_idle_windows():
+    """When there are no insertable idle windows, info reports zeros."""
+    q = cirq.LineQubit(0)
+    # No multi-moment idle windows: consecutive non-identity ops only.
+    circuit = cirq.Circuit(cirq.H(q), cirq.X(q), cirq.H(q))
+    circuit_with_ddd, info = insert_ddd_sequences(
+        circuit, rule=xx, return_info=True
+    )
+
+    assert circuit_with_ddd == circuit
+    assert info.num_idle_windows == 0
+    assert info.num_sequences_inserted == 0
+    assert info.idle_window_lengths == ()
+
+
+def test_insert_ddd_sequences_return_info_empty_rule():
+    """Idle windows counted even if the rule inserts nothing."""
+
+    def empty_rule(slack_length: int) -> cirq.Circuit:
+        return cirq.Circuit()
+
+    qubits = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.ops.H.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.H.on_each(*qubits),
+    )
+    circuit_with_ddd, info = insert_ddd_sequences(
+        circuit, rule=empty_rule, return_info=True
+    )
+
+    assert circuit_with_ddd == circuit
+    assert info.num_idle_windows == 2
+    assert info.num_sequences_inserted == 0
+    assert info.idle_window_lengths == (2, 2)
+
+
+def test_insert_ddd_sequences_return_info_qiskit():
+    """return_info works through frontend conversion (Qiskit)."""
+    qreg = qiskit.QuantumRegister(2)
+    circuit = qiskit.QuantumCircuit(qreg)
+    circuit.h(0)
+    circuit.h(1)
+    circuit.id(0)
+    circuit.id(1)
+    circuit.id(0)
+    circuit.id(1)
+    circuit.h(0)
+    circuit.h(1)
+
+    result, info = insert_ddd_sequences(circuit, rule=xx, return_info=True)
+    assert isinstance(result, qiskit.QuantumCircuit)
+    assert info.num_idle_windows >= 1
+    assert info.num_sequences_inserted == info.num_idle_windows

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -247,31 +247,45 @@ def accept_any_qprogram_as_input(
 
 def atomic_converter(
     cirq_circuit_modifier: Callable[..., Any],
+    returns_extra: bool = False,
 ) -> Callable[..., Any]:
     """Decorator which allows for a function which inputs and returns a Cirq
     circuit to input and return any QPROGRAM.
 
     Args:
         cirq_circuit_modifier: Function which inputs a Cirq circuit and returns
-            a (potentially modified) Cirq circuit.
+            a (potentially modified) Cirq circuit. If ``returns_extra`` is
+            ``True``, it must return ``(circuit, extra)`` instead.
+        returns_extra: If ``True``, ``cirq_circuit_modifier`` is expected to
+            return ``(cirq.Circuit, extra)``. The converted circuit is
+            returned as ``(QPROGRAM, extra)``.
     """
 
     @wraps(cirq_circuit_modifier)
     def qprogram_modifier(
         circuit: QPROGRAM, *args: Any, **kwargs: Any
-    ) -> QPROGRAM:
+    ) -> QPROGRAM | tuple[QPROGRAM, Any]:
         # Convert to Mitiq representation.
         mitiq_circuit, input_circuit_type = convert_to_mitiq(circuit)
 
         # Modify the Cirq circuit.
-        scaled_circuit = cirq_circuit_modifier(mitiq_circuit, *args, **kwargs)
+        result = cirq_circuit_modifier(mitiq_circuit, *args, **kwargs)
+        if returns_extra:
+            scaled_circuit, extra = result
+        else:
+            scaled_circuit = result
+            extra = None
 
         if kwargs.get("return_mitiq") is True:
+            if returns_extra:
+                return scaled_circuit, extra
             return scaled_circuit
 
         # Base conversion back to input type.
         scaled_circuit = convert_from_mitiq(scaled_circuit, input_circuit_type)
 
+        if returns_extra:
+            return scaled_circuit, extra
         return scaled_circuit
 
     return qprogram_modifier
@@ -308,6 +322,7 @@ def atomic_one_to_many_converter(
 def accept_qprogram_and_validate(
     cirq_circuit_modifier: Callable[..., Any],
     one_to_many: bool = False,
+    returns_extra: bool = False,
 ) -> Callable[..., Any]:
     """This decorator performs two functions:
 
@@ -320,14 +335,21 @@ def accept_qprogram_and_validate(
         cirq_circuit_modifier: The function modifying a Cirq circuit.
         one_to_many: If True, ``cirq_circuit_modifier`` is expected to return
             a sequence of Cirq circuits instead of a single Cirq circuit.
+        returns_extra: If True, ``cirq_circuit_modifier`` is expected to
+            return ``(cirq.Circuit, extra)``. The converted result is
+            ``(QPROGRAM, extra)``. Cannot be combined with ``one_to_many``.
 
     Returns:
         The transformed function which can take any QPROGRAM, and performs
         circuit-level validation.
     """
+    if one_to_many and returns_extra:
+        raise ValueError("one_to_many and returns_extra cannot be combined.")
 
     @wraps(cirq_circuit_modifier)
-    def new_function(circuit: QPROGRAM, *args: Any, **kwargs: Any) -> QPROGRAM:
+    def new_function(
+        circuit: QPROGRAM, *args: Any, **kwargs: Any
+    ) -> QPROGRAM | list[QPROGRAM] | tuple[QPROGRAM, Any]:
         # Pre atomic conversion
         if "qiskit" in circuit.__module__:
             from qiskit.transpiler.passes import RemoveBarriers
@@ -344,14 +366,19 @@ def accept_qprogram_and_validate(
             # when converting to Cirq. Eventually, identities will be removed.
             idle_qubits = _add_identity_to_idle(circuit)
 
+        extra_value: Any = None
         if one_to_many:
             out_circuits = atomic_one_to_many_converter(cirq_circuit_modifier)(
                 circuit, *args, **kwargs
             )
         else:
-            out_circuit = atomic_converter(cirq_circuit_modifier)(
-                circuit, *args, **kwargs
-            )
+            converted = atomic_converter(
+                cirq_circuit_modifier, returns_extra=returns_extra
+            )(circuit, *args, **kwargs)
+            if returns_extra:
+                out_circuit, extra_value = converted
+            else:
+                out_circuit = converted
             out_circuits = [out_circuit]
 
         circuits_to_return = []
@@ -418,6 +445,8 @@ def accept_qprogram_and_validate(
 
         if not one_to_many:
             assert len(circuits_to_return) == 1
+            if returns_extra:
+                return circuits_to_return[0], extra_value
             return circuits_to_return[0]
 
         return circuits_to_return

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -85,6 +85,18 @@ one_to_many_circuit_modifier = accept_qprogram_and_validate(
 )
 
 
+def circuit_modifier_with_extra(
+    circ: cirq.Circuit, *args, **kwargs
+) -> tuple[cirq.Circuit, dict[str, int]]:
+    return circ, {"n_moments": len(circ)}
+
+
+circuit_modifier_with_extra = accept_qprogram_and_validate(
+    circuit_modifier_with_extra,
+    returns_extra=True,
+)
+
+
 @accept_any_qprogram_as_input
 def get_wavefunction(circ: cirq.Circuit) -> np.ndarray:
     return circ.final_state_vector()
@@ -250,6 +262,29 @@ def test_atomic_one_to_many_converter(to_type):
     circuits = returns_several_circuits(circuit, return_mitiq=True)
     for circuit in circuits:
         assert isinstance(circuit, cirq.Circuit)
+
+
+@pytest.mark.parametrize(
+    "circuit_and_type",
+    (
+        (cirq_circuit, "cirq"),
+        (qiskit_circuit, "qiskit"),
+        (pyquil_circuit, "pyquil"),
+        (braket_circuit, "braket"),
+    ),
+)
+def test_accept_qprogram_and_validate_returns_extra(circuit_and_type):
+    circuit, input_type = circuit_and_type
+    converted, extra = circuit_modifier_with_extra(circuit)
+    assert isinstance(converted, circuit_types[input_type])
+    assert extra == {"n_moments": 2}
+
+
+def test_accept_qprogram_and_validate_returns_extra_rejects_one_to_many():
+    with pytest.raises(ValueError, match="cannot be combined"):
+        accept_qprogram_and_validate(
+            scaling_function, one_to_many=True, returns_extra=True
+        )
 
 
 def test_noise_scaling_converter_with_qiskit_idle_qubits_and_barriers():


### PR DESCRIPTION
Fixes #2882

## Description

Add opt-in insertion metadata with `return_info=True`. By default, `insert_ddd_sequences` returns one circuit and `construct_circuits` returns a list of circuits. The opt-in forms return `(circuit, DDDInfo)` and `(circuits, tuple_of_DDDInfo)` respectively.

The Cirq implementation returns the circuit and immutable metadata together; frontend conversion preserves the extra return value. No caller-facing mutable output parameter is used. Literal and boolean fallback overloads describe the supported return forms.

`construct_circuits` logs one INFO summary per trial on `mitiq.ddd`. Low-level insertion does not log, avoiding duplicate output.

This description correction adds no new validation claim; the existing review replies and CI results remain the test record.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.

### AI disclosure

AI tools helped draft code and the original description. ChatGPT assisted with this description correction; the existing license declaration is retained, not newly signed.
