### PR TITLE
Extend amplitude damping representation to compatible QPROGRAM frontends

### DIFF
--- a/mitiq/pec/representations/damping.py
+++ b/mitiq/pec/representations/damping.py
@@ -8,15 +8,32 @@ from itertools import product
 
 import numpy as np
 import numpy.typing as npt
-from cirq import AmplitudeDampingChannel, Circuit, Z, kraus, reset
+from cirq import (
+    AmplitudeDampingChannel,
+    Circuit,
+    ResetChannel,
+    Z,
+    kraus,
+    reset,
+)
 
+from mitiq import QPROGRAM
+from mitiq.interface.conversions import (
+    CircuitConversionError,
+    append_cirq_circuit_to_qprogram,
+    convert_to_mitiq,
+)
 from mitiq.pec.types import NoisyOperation, OperationRepresentation
 from mitiq.utils import arbitrary_tensor_product
 
 
-# TODO: this may be extended to an arbitrary QPROGRAM (GitHub issue gh-702).
+# Partial support for arbitrary QPROGRAM inputs (GitHub issue gh-702):
+# extension to the remaining frontends is blocked on their conversion
+# paths carrying the non-unitary reset operation — a converter-level gap
+# for pyQuil and PennyLane, a language-level gap for Braket and Qibo
+# (see the docstring note).
 def _represent_operation_with_amplitude_damping_noise(
-    ideal_operation: Circuit,
+    ideal_operation: QPROGRAM,
     noise_level: float,
     is_qubit_dependent: bool = True,
 ) -> OperationRepresentation:
@@ -43,6 +60,12 @@ def _represent_operation_with_amplitude_damping_noise(
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
 
+    Raises:
+        ValueError: If the input operation acts on more than one qubit.
+        CircuitConversionError: If the frontend of ``ideal_operation``
+            cannot faithfully represent the non-unitary reset operation
+            contained in the basis of implementable operations.
+
     .. note::
         The input ``ideal_operation`` is typically a QPROGRAM with a single
         gate but could also correspond to a sequence of more gates.
@@ -51,15 +74,23 @@ def _represent_operation_with_amplitude_damping_noise(
         physically implementable.
 
     .. note::
-        The input ``ideal_operation`` must be a ``cirq.Circuit``.
+        The basis of implementable operations contains a non-unitary reset
+        operation, so this representation can only be returned for
+        frontends whose Mitiq conversions preserve reset. These are
+        currently Cirq and Qiskit circuits, as well as the OpenQASM 2.0
+        strings returned by
+        ``mitiq.interface.convert_from_mitiq(circuit, "openqasm")``.
+        For the other frontends a ``CircuitConversionError`` is raised
+        instead of returning a physically incorrect representation:
+        the Cirq-to-pyQuil converter does not support
+        ``cirq.ResetChannel`` (although pyQuil itself has a ``RESET``
+        instruction), the Braket circuit model has no reset instruction,
+        the Qibo OpenQASM parser rejects reset statements, and the
+        PennyLane converter silently discards the reset.
     """
+    converted_circ, input_circuit_type = convert_to_mitiq(ideal_operation)
 
-    if not isinstance(ideal_operation, Circuit):
-        raise NotImplementedError(
-            "The input ideal_operation must be a cirq.Circuit.",
-        )
-
-    qubits = ideal_operation.all_qubits()
+    qubits = converted_circ.all_qubits()
 
     if len(qubits) == 1:
         q = tuple(qubits)[0]
@@ -71,13 +102,39 @@ def _represent_operation_with_amplitude_damping_noise(
         post_ops = [[], Z(q), reset(q)]
 
     else:
-        raise ValueError(  # pragma: no cover
-            "Only single-qubit operations are supported."  # pragma: no cover
-        )  # pragma: no cover
+        raise ValueError("Only single-qubit operations are supported.")
 
     # Basis of implementable operations as circuits
-    imp_op_circuits = [ideal_operation + Circuit(op) for op in post_ops]
+    imp_op_circuits = [
+        append_cirq_circuit_to_qprogram(
+            ideal_operation,
+            Circuit(op),
+        )
+        for op in post_ops
+    ]
     noisy_operations = [NoisyOperation(c) for c in imp_op_circuits]
+
+    # The last basis element ends with a non-unitary reset. Some frontend
+    # conversions accept it but silently delete the reset, which would make
+    # the returned representation wrong at any nonzero noise level. The
+    # round trip through the native frontend must keep every reset and
+    # keep the appended reset as the final operation.
+    num_ideal_resets = sum(
+        isinstance(op.gate, ResetChannel)
+        for op in converted_circ.all_operations()
+    )
+    roundtrip_ops = list(noisy_operations[-1].circuit.all_operations())
+    num_roundtrip_resets = sum(
+        isinstance(op.gate, ResetChannel) for op in roundtrip_ops
+    )
+    if num_roundtrip_resets != num_ideal_resets + 1 or not isinstance(
+        roundtrip_ops[-1].gate, ResetChannel
+    ):
+        raise CircuitConversionError(
+            f"Conversion to the circuit type '{input_circuit_type}' does "
+            "not preserve the non-unitary reset operation required by the "
+            "amplitude damping representation."
+        )
 
     return OperationRepresentation(
         ideal_operation, noisy_operations, etas, is_qubit_dependent

--- a/mitiq/pec/representations/tests/test_damping.py
+++ b/mitiq/pec/representations/tests/test_damping.py
@@ -5,9 +5,19 @@
 
 import numpy as np
 import pytest
-from cirq import AmplitudeDampingChannel, Circuit, Gate, H, LineQubit, X, Y, Z
+from cirq import (
+    CNOT,
+    AmplitudeDampingChannel,
+    Circuit,
+    Gate,
+    H,
+    LineQubit,
+    X,
+    Y,
+    Z,
+)
 
-from mitiq.interface import convert_from_mitiq
+from mitiq.interface import CircuitConversionError, convert_from_mitiq
 from mitiq.pec.channels import _circuit_to_choi, _operation_to_choi
 from mitiq.pec.representations.damping import (
     _represent_operation_with_amplitude_damping_noise,
@@ -27,9 +37,11 @@ def test_single_qubit_representation_norm(gate: Gate, noise: float):
     assert np.isclose(optimal_norm, norm)
 
 
-# When _represent_operation_with_amplitude_damping_noise will
-# support more circuit types we can add them below.
-@pytest.mark.parametrize("circuit_type", ["cirq"])
+# The Mitiq conversions for the remaining frontends (pyquil, braket,
+# qibo, pennylane) cannot faithfully carry the non-unitary reset
+# operation of the basis; see
+# test_amplitude_damping_representation_unsupported_frontend_raises.
+@pytest.mark.parametrize("circuit_type", ["cirq", "qiskit", "openqasm"])
 @pytest.mark.parametrize("noise", [0, 0.1, 0.7])
 @pytest.mark.parametrize("gate", [X, Y, Z, H])
 def test_amplitude_damping_representation_with_choi(
@@ -48,6 +60,12 @@ def test_amplitude_damping_representation_with_choi(
     choi_components = []
     for coeff, noisy_op in op_rep.basis_expansion:
         implementable_circ = noisy_op.circuit
+        # Frontend round trips may rename the qubit (e.g. to a
+        # NamedQubit), while _operation_to_choi assumes LineQubit(0).
+        (current_qubit,) = implementable_circ.all_qubits()
+        implementable_circ = implementable_circ.transform_qubits(
+            {current_qubit: q}
+        )
         depolarizing_op = AmplitudeDampingChannel(noise).on(q)
         # Apply noise after each sequence.
         # NOTE: noise is not applied after each operation.
@@ -57,6 +75,68 @@ def test_amplitude_damping_representation_with_choi(
 
     combination_choi = np.sum(choi_components, axis=0)
     assert np.allclose(ideal_choi, combination_choi, atol=1e-7)
+
+
+@pytest.mark.parametrize(
+    "circuit_type", ["pyquil", "braket", "qibo", "pennylane"]
+)
+@pytest.mark.parametrize("noise", [0, 0.1])
+def test_amplitude_damping_representation_unsupported_frontend_raises(
+    circuit_type: str,
+    noise: float,
+):
+    """Frontends whose conversions cannot carry the non-unitary reset must
+    raise instead of returning a physically wrong representation.
+
+    The pyquil, braket and qibo conversions raise while converting the
+    reset-bearing basis circuit (for pyquil the blocker is the
+    Cirq-to-pyQuil converter, not the pyQuil language, which has a
+    ``RESET`` instruction). The pennylane conversion instead succeeds
+    and silently deletes the reset; since the reset coefficient
+    ``eta_2 = -noise / (1 - noise)`` vanishes at ``noise = 0``, the loss
+    is invisible in any zero-noise check, so the raise must be
+    deterministic and independent of the noise level.
+    """
+    ideal_circuit = convert_from_mitiq(Circuit(X(LineQubit(0))), circuit_type)
+    with pytest.raises(CircuitConversionError):
+        _represent_operation_with_amplitude_damping_noise(
+            ideal_circuit,
+            noise,
+        )
+
+
+def test_amplitude_damping_representation_pennylane_reset_loss_is_loud():
+    """The pennylane converter drops the reset with only a warning, which
+    would otherwise return a representation that is type-valid but wrong
+    for any nonzero noise. The error must name the offending frontend and
+    the unsupported reset operation."""
+    ideal_circuit = convert_from_mitiq(Circuit(X(LineQubit(0))), "pennylane")
+    with pytest.raises(CircuitConversionError) as excinfo:
+        _represent_operation_with_amplitude_damping_noise(ideal_circuit, 0.1)
+    assert "pennylane" in str(excinfo.value)
+    assert "reset" in str(excinfo.value)
+
+
+def test_amplitude_damping_representation_openqasm_string():
+    """The OpenQASM support of this representation is exactly the
+    ``QasmStringType`` OpenQASM 2.0 string produced by
+    ``convert_from_mitiq(circuit, "openqasm")``; the representation built
+    from it has the expected norm."""
+    noise = 0.1
+    qasm = convert_from_mitiq(Circuit(X(LineQubit(0))), "openqasm")
+    assert "OPENQASM 2.0;" in qasm
+
+    op_rep = _represent_operation_with_amplitude_damping_noise(qasm, noise)
+    assert np.isclose(op_rep.norm, (1 + noise) / (1 - noise))
+
+
+def test_amplitude_damping_representation_two_qubits_raises():
+    q0, q1 = LineQubit.range(2)
+    with pytest.raises(ValueError, match="single-qubit"):
+        _represent_operation_with_amplitude_damping_noise(
+            Circuit(CNOT(q0, q1)),
+            0.1,
+        )
 
 
 def test_damping_kraus():


### PR DESCRIPTION
## Summary

Extends `_represent_operation_with_amplitude_damping_noise` beyond its previous Cirq-only implementation as progress toward #702.

The representation now accepts `QPROGRAM` inputs and supports frontends whose conversion paths faithfully preserve the non-unitary reset operation required by the amplitude damping PEC basis.

Currently verified:

- Cirq
- Qiskit
- Mitiq-generated OpenQASM 2.0

For frontends whose conversion paths cannot preserve reset correctly, the function now raises `CircuitConversionError` rather than returning a representation with incorrect channel semantics.

## Why this needs special handling

The amplitude damping representation uses the basis:

- identity
- Z
- reset

Unlike the unitary Pauli corrections used by the depolarizing representations, `reset` is non-unitary and is not preserved consistently across Mitiq's frontend conversions.

In particular, some conversions fail outright while others can return a valid-looking circuit after dropping the reset operation. The latter case is especially dangerous because the returned representation can be structurally valid while being physically incorrect.

This change therefore validates that the reset operation survives the frontend round trip before returning the representation.

## Frontend behavior

| Frontend | Result |
|---|---|
| Cirq | Supported |
| Qiskit | Supported |
| OpenQASM 2.0 generated by Mitiq | Supported |
| pyQuil | Unsupported by current Cirq → pyQuil conversion path |
| Braket | Reset not supported by the circuit model |
| Qibo | OpenQASM parser rejects reset |
| PennyLane | Conversion can silently drop reset, so the representation is rejected |

The validation is based on the resulting circuit behavior rather than a hard-coded frontend denylist, so a frontend can become supported automatically if its conversion path gains correct reset support.

## Testing

Expanded the existing Choi-matrix reconstruction test across the supported frontends and added coverage for unsupported conversion paths.

Targeted tests:

```text
60 passed
```

Full verification:

```text
make check-all
✓ Ruff
✓ Ruff format
✓ mypy

make test
2603 passed
2 xfailed
96% coverage
```

The PEC coefficients and basis mathematics are unchanged.

## Scope

This does not attempt to add reset support to every frontend conversion layer.

Instead, it extends the amplitude damping representation where reset can currently be represented faithfully and fails explicitly where it cannot.

Further frontend support, particularly the Cirq → pyQuil reset conversion path, can be handled independently.
