### PR TITLE
Fix PolyExpFactory extrapolation curve when avoid_log=True

### DIFF
--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -1416,8 +1416,14 @@ class PolyExpFactory(BatchedFactory):
             # The zero noise limit is ansatz(0)= asymptote + b
             zne_limit = asymptote + opt_params[0]
 
+            # Bind the fitted parameters to a name that is not rebound
+            # below: `opt_params` gains a leading `asymptote` entry, and a
+            # closure over it would evaluate the ansatz with a shifted
+            # parameter list.
+            fit_params = list(opt_params)
+
             def zne_curve(scale_factor: float) -> float:
-                return _ansatz_known(scale_factor, *opt_params)
+                return _ansatz_known(scale_factor, *fit_params)
 
             # Use propagation of errors to calculate zne_error
             if params_cov is not None:

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -1410,17 +1410,11 @@ class PolyExpFactory(BatchedFactory):
         if avoid_log:
             # First guess for the parameters
             p_zero = [sign, -1.0] + [0.0 for _ in range(order - 1)]
-            opt_params, params_cov = mitiq_curve_fit(
+            fit_params, params_cov = mitiq_curve_fit(
                 _ansatz_known, scale_factors, exp_values, p_zero
             )
             # The zero noise limit is ansatz(0)= asymptote + b
-            zne_limit = asymptote + opt_params[0]
-
-            # Bind the fitted parameters to a name that is not rebound
-            # below: `opt_params` gains a leading `asymptote` entry, and a
-            # closure over it would evaluate the ansatz with a shifted
-            # parameter list.
-            fit_params = list(opt_params)
+            zne_limit = asymptote + fit_params[0]
 
             def zne_curve(scale_factor: float) -> float:
                 return _ansatz_known(scale_factor, *fit_params)
@@ -1430,7 +1424,9 @@ class PolyExpFactory(BatchedFactory):
                 if params_cov.shape == (order + 1, order + 1):
                     zne_error = np.sqrt(params_cov[0, 0])
 
-            opt_params = [asymptote] + list(opt_params)
+            # The reported parameters describe the full ansatz, so they
+            # carry the asymptote that `_ansatz_known` takes as given.
+            opt_params = [asymptote] + list(fit_params)
 
             if full_output:
                 return (

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -1019,3 +1019,124 @@ def test_extrapolate_raises_error_on_complex_expectation_values():
     PolyExpFactory.extrapolate(
         scale_factors=[1, 2, 3], exp_values=[1, 0.5 + 1e-5j, 6], order=1
     )
+
+
+def test_poly_exp_factory_bad_asymptote_type():
+    """``asymptote`` must be a float or None, and an int is neither.
+
+    ``ExpFactory`` already covers the complex case, but it does not
+    subclass ``PolyExpFactory``, so this check is a separate branch.
+    """
+    with raises(ValueError, match="must be either a float or None"):
+        PolyExpFactory(X_VALS, order=1, asymptote=1)
+
+
+@mark.parametrize(
+    "scale_factors, exp_values",
+    [
+        (None, None),
+        ([1.0, 2.0, 3.0], None),
+        ([1.0, 2.0], [1.0]),  # mismatched lengths
+        ([1.0], [1.0]),  # fewer than two points
+        ([], []),
+    ],
+)
+def test_poly_exp_factory_extrapolate_insufficient_data(
+    scale_factors, exp_values
+):
+    """Missing, mismatched, or too-short data is rejected."""
+    with raises(ValueError, match="at least two data points are necessary"):
+        PolyExpFactory.extrapolate(scale_factors, exp_values, order=1)
+
+
+def test_poly_exp_factory_extrapolate_order_too_high():
+    """The fit order cannot exceed what the data can determine.
+
+    With an unknown asymptote the ansatz costs an extra degree of
+    freedom, so the same order that is fine with a known asymptote is
+    rejected without one.
+    """
+    scale_factors = [1.0, 2.0, 3.0]
+    exp_values = [0.9, 0.8, 0.72]
+
+    with raises(ValueError, match="Extrapolation order is too high"):
+        PolyExpFactory.extrapolate(
+            scale_factors, exp_values, order=3, asymptote=0.5
+        )
+
+    # Legal with a known asymptote, rejected without one.
+    PolyExpFactory.extrapolate(
+        scale_factors, exp_values, order=2, asymptote=0.5
+    )
+    with raises(ValueError, match="Extrapolation order is too high"):
+        PolyExpFactory.extrapolate(scale_factors, exp_values, order=2)
+
+
+@mark.parametrize(
+    "asymptote, avoid_log",
+    [
+        (None, False),  # unknown asymptote
+        (A, False),  # known asymptote, fitted in log space
+        (A, True),  # known asymptote, avoiding the log
+    ],
+)
+def test_poly_exp_factory_zne_curve_interpolates_data(asymptote, avoid_log):
+    """The returned curve reproduces the fitted points and zne_limit.
+
+    ``PolyExpFactory.extrapolate`` builds a separate closure for each of
+    its three cases (unknown asymptote, known asymptote with
+    ``avoid_log``, and known asymptote via the log fit), so all three are
+    exercised. Asserting values rather than merely calling the curve is
+    what makes this a regression test: a curve that ignored its fitted
+    parameters would still be callable.
+    """
+    scale_factors = [1.0, 1.5, 2.0, 2.5]
+    exp_values = [f_exp_down(s, err=0) for s in scale_factors]
+
+    zne_limit, _, _, _, zne_curve = PolyExpFactory.extrapolate(
+        scale_factors,
+        exp_values,
+        order=1,
+        asymptote=asymptote,
+        avoid_log=avoid_log,
+        full_output=True,
+    )
+
+    assert np.isclose(zne_curve(0.0), zne_limit, atol=CLOSE_TOL)
+    for scale_factor, exp_value in zip(scale_factors, exp_values):
+        assert np.isclose(zne_curve(scale_factor), exp_value, atol=CLOSE_TOL)
+
+
+def test_fake_nodes_factory_zne_curve_interpolates_data():
+    """``FakeNodesFactory``'s curve is mapped back to the real space.
+
+    The fit happens in "fake node space", so the returned curve has to
+    map its argument through ``_map_to_fake_nodes`` before evaluating.
+    Omitting that mapping would still produce a callable curve, but it
+    would not pass through the measured points.
+    """
+    scale_factors = [1.0, 1.5, 2.0, 2.5]
+    exp_values = [f_exp_down(s, err=0) for s in scale_factors]
+
+    zne_limit, _, _, _, zne_curve = FakeNodesFactory.extrapolate(
+        scale_factors, exp_values, full_output=True
+    )
+
+    assert np.isclose(zne_curve(0.0), zne_limit, atol=CLOSE_TOL)
+    for scale_factor, exp_value in zip(scale_factors, exp_values):
+        assert np.isclose(zne_curve(scale_factor), exp_value, atol=CLOSE_TOL)
+
+
+def test_ada_exp_factory_is_converged_unequal_stacks():
+    """``is_converged`` refuses to answer from inconsistent state.
+
+    ``self._instack`` and ``self._outstack`` are appended in lockstep,
+    so a length mismatch means a circuit was recorded without its
+    result. Answering True or False there would hide the inconsistency.
+    """
+    fac = AdaExpFactory(steps=4, scale_factor=2.0, asymptote=None)
+    fac._instack = [{"scale_factor": 1.0}, {"scale_factor": 2.0}]
+    fac._outstack = [1.0]
+
+    with raises(IndexError, match="must be equal"):
+        fac.is_converged()


### PR DESCRIPTION
### Description

`PolyExpFactory.extrapolate()` returns a curve that does not pass through the fitted data when an asymptote is given together with `avoid_log=True`.

Measured through the public API on a noiseless exponential `y(x) = 0.5 + 0.7·exp(-0.4x)`, via `ExpFactory(..., asymptote=0.5, avoid_log=True).get_extrapolation_curve()`:

| code path | `max\|curve(x) − y(x)\|` before | after |
|---|---|---|
| CASE 1 — `asymptote=None` | 3.33e-16 | 3.33e-16 (unchanged) |
| **CASE 2 — asymptote given, `avoid_log=True`** | **2.06e-01** | **1.11e-16** |
| CASE 3 — asymptote given, `avoid_log=False` | 3.33e-16 | 3.33e-16 (unchanged) |

This is user-visible through `Factory.plot_fit()`, which draws its "Best fit" line from this curve — so the plotted fit visibly misses the plotted data points.

### Cause

`zne_curve` closes over the *name* `opt_params`, and a few lines later that name is rebound:

```python
zne_limit = asymptote + opt_params[0]

def zne_curve(scale_factor: float) -> float:
    return _ansatz_known(scale_factor, *opt_params)   # closes over the name

...
opt_params = [asymptote] + list(opt_params)           # rebinds it
```

Python closures capture by name, not by value, so by the time a caller invokes the returned curve, `opt_params` has an extra leading entry and the ansatz is evaluated with its parameters shifted by one — the asymptote is used as the amplitude. Concretely, a fit that produced `b=0.7, z=[-0.4]` was evaluated as `b=0.5, z=[0.7, -0.4]`.

`zne_limit` reads `opt_params[0]` *before* the rebinding and so was always correct, which is why the discrepancy has gone unnoticed: the extrapolated value is right and only the curve is wrong.

The fix binds the fitted parameters to a name that is not rebound. The other two branches are unaffected — CASE 1 never rebinds `opt_params`, and CASE 3 closes over `z_coefficients`, a different name — and both measure 3e-16 before and after.

### Tests

Also adds tests for the lines listed in #2365 for `mitiq/zne/inference.py` and `mitiq/zne/zne.py`, since that is what surfaced the bug above:

- `PolyExpFactory.__init__` rejecting a non-float, non-None `asymptote` (`ExpFactory` covers the complex case but does not subclass `PolyExpFactory`, so it is a separate branch)
- `PolyExpFactory.extrapolate` rejecting missing / mismatched / too-short data, and an order too high for the data
- `AdaExpFactory.is_converged` on inconsistent `_instack`/`_outstack`
- the extrapolation curves of `PolyExpFactory` (all three cases) and `FakeNodesFactory`

The curve tests assert that the curve reproduces the fitted points and `zne_limit`, rather than only that it is callable — a curve that ignored its fitted parameters would still be callable, and that assertion is what catches this bug. Each new test was verified to fail when the line it covers is broken; the `avoid_log=True` case is the only one of the three parametrizations that fails on current `main`.

Coverage of `mitiq/zne/inference.py` goes from 98% to 99%.

### Verified locally

```
pytest mitiq/zne/ mitiq/executor/    400 passed, 1 xfailed
ruff check                           All checks passed!
ruff format --check                  2 files already formatted
mypy mitiq/zne/inference.py          no new errors
```

### Note on two lines from #2365 I deliberately did not cover

- `mitiq/calibration/settings.py:270` (`return None` in `num_circuits_required`) looks genuinely unreachable: `MitigationTechnique` has exactly three members and all three are handled above it. That seems like a `# pragma: no cover` candidate rather than a test, but it is a source change on an unrelated module so I left it out of this PR — happy to add it if you'd prefer.
- `mitiq/executor/executor.py:183-184` (the `isinstance(observable, PauliString)` branch of the hermitian check) appears to be dead: a bare `PauliString` passed as `observable` fails for every executor return type (`AttributeError: 'PauliString' object has no attribute 'ngroups'` / `'_expectation_from_measurements'`), and the branch was added when the annotation was already `Optional[Observable]`. A test there would have to assert-and-swallow an unrelated crash, so it seemed better to mention it than to paper over it. Let me know if you'd like that as a separate issue.

Assisted-by: Claude (Anthropic). I ran and verified every number quoted above, and the rationale for the fix is mine — per the AI use policy in `CONTRIBUTING.md`.
