### PR TITLE
Cover multi-qubit gate arity counting across frontends (#2365)

### DIFF
--- a/mitiq/tests/test_utils.py
+++ b/mitiq/tests/test_utils.py
@@ -502,3 +502,38 @@ def test_compare_cost_with_shots(circuit_type):
     qem_native = [convert_from_mitiq(c, circuit_type) for c in qem_circuits]
     cost = compare_cost(base_native, qem_native, shots=100)
     assert cost["shots_per_circuit"] == 50
+
+
+@pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())
+def test_compare_cost_counts_multi_qubit_gates(circuit_type):
+    """Gates on three or more qubits are counted under ``nq``.
+
+    ``test_compare_cost_basic`` asserts ``"nq": 0``, so the arity counters
+    have only ever been exercised on 1- and 2-qubit gates. Each frontend
+    counts arity with its own code path, and this pins that all of them
+    agree on a 3-qubit gate rather than silently dropping it or filing it
+    under ``2q``.
+    """
+    q0, q1, q2 = cirq.LineQubit.range(3)
+    base = cirq.Circuit(
+        cirq.H(q0),
+        cirq.CNOT(q0, q1),
+        cirq.TOFFOLI(q0, q1, q2),
+        cirq.measure(q0, q1, q2),
+    )
+    qem_circuits = [
+        base,
+        cirq.Circuit(
+            cirq.H(q0),
+            cirq.CNOT(q0, q1),
+            cirq.TOFFOLI(q0, q1, q2),
+            cirq.CSWAP(q0, q1, q2),
+            cirq.measure(q0, q1, q2),
+        ),
+    ]
+    base_native = convert_from_mitiq(base, circuit_type)
+    qem_native = [convert_from_mitiq(c, circuit_type) for c in qem_circuits]
+
+    cost = compare_cost(base_native, qem_native)
+
+    assert cost["gate_overhead"] == {"1q": 1, "2q": 1, "nq": 2}


### PR DESCRIPTION
### Description

Covers the `nq` (three-or-more-qubit) branch of the per-frontend gate arity counters in `mitiq/interface/utils.py`, one of the files listed in #2365. Tests only — no source changes.

**Why these were uncovered:** `test_compare_cost_basic` and `test_compare_cost_with_shots` both assert `"nq": 0`, so the counters have only ever been exercised on 1- and 2-qubit gates. Each frontend counts arity through its own function (`_count_gate_arities_cirq`, `_qiskit`, `_pyquil`, `_braket`, `_pennylane`, `_qibo`), so all six `nq` branches were dead in the test suite.

**What the test pins:** a circuit with a 1-qubit, a 2-qubit and two 3-qubit gates, converted to every supported program type, must give `{"1q": 1, "2q": 1, "nq": 2}` through the public `compare_cost`. All seven agree. That cross-frontend agreement is the invariant worth guarding — a frontend that silently dropped a 3-qubit gate, or filed it under `2q`, would previously have gone unnoticed.

Coverage of `mitiq/interface/utils.py`: **90.8% → 96%** (12 missing lines → 5; the remaining 5 are error paths and braket's measurement skip).

Each of the six `counts["nq"] += 1` statements was neutralised in turn to confirm the test catches it:

```
line  32 (cirq)       -> 2 failed
line  53 (qiskit)     -> 1 failed
line  74 (pyquil)     -> 1 failed
line  95 (braket)     -> 1 failed
line 116 (pennylane)  -> 1 failed
line 137 (qibo)       -> 1 failed
```

### Verified locally

```
pytest mitiq/tests/test_utils.py     59 passed
ruff check                           All checks passed!
ruff format --check                  1 file already formatted
```

Assisted-by: Claude (Anthropic). Every number above was run and verified, per the AI use policy in `CONTRIBUTING.md`.
