### PR TITLE
Support non-LineQubit circuits in to_braket

### DIFF
--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -2,6 +2,7 @@
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
+import itertools
 from typing import cast
 from warnings import warn
 
@@ -53,18 +54,28 @@ def from_braket(circuit: BKCircuit) -> Circuit:
 def to_braket(circuit: Circuit) -> BKCircuit:
     """Returns a Braket circuit equivalent to the input Cirq circuit.
 
-    Braket addresses qubits by integer index, so qubits that are not
-    ``cirq.LineQubit`` are relabelled to ``cirq.LineQubit`` in sorted order
-    first. This leaves ``LineQubit`` circuits untouched, and preserves the
-    unitary for the rest.
+    Braket addresses qubits by integer index. ``LineQubit`` indices are
+    carried through unchanged, including in a circuit that mixes them with
+    other qubit types; any qubit that is not a ``LineQubit`` is assigned the
+    lowest index not already taken by one.
 
     Args:
         circuit: Cirq circuit to convert to a Braket circuit.
     """
-    qubits = sorted(circuit.all_qubits())
-    if any(not isinstance(qubit, LineQubit) for qubit in qubits):
+    other_qubits = sorted(
+        qubit
+        for qubit in circuit.all_qubits()
+        if not isinstance(qubit, LineQubit)
+    )
+    if other_qubits:
+        taken = {
+            qubit.x
+            for qubit in circuit.all_qubits()
+            if isinstance(qubit, LineQubit)
+        }
+        free = (index for index in itertools.count() if index not in taken)
         circuit = circuit.transform_qubits(
-            {qubit: LineQubit(index) for index, qubit in enumerate(qubits)}
+            {qubit: LineQubit(next(free)) for qubit in other_qubits}
         )
 
     return BKCircuit(

--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -53,9 +53,20 @@ def from_braket(circuit: BKCircuit) -> Circuit:
 def to_braket(circuit: Circuit) -> BKCircuit:
     """Returns a Braket circuit equivalent to the input Cirq circuit.
 
+    Braket addresses qubits by integer index, so qubits that are not
+    ``cirq.LineQubit`` are relabelled to ``cirq.LineQubit`` in sorted order
+    first. This leaves ``LineQubit`` circuits untouched, and preserves the
+    unitary for the rest.
+
     Args:
         circuit: Cirq circuit to convert to a Braket circuit.
     """
+    qubits = sorted(circuit.all_qubits())
+    if any(not isinstance(qubit, LineQubit) for qubit in qubits):
+        circuit = circuit.transform_qubits(
+            {qubit: LineQubit(index) for index, qubit in enumerate(qubits)}
+        )
+
     return BKCircuit(
         _translate_cirq_operation_to_braket_instruction(op)
         for op in circuit.all_operations()

--- a/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
+++ b/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
@@ -456,3 +456,59 @@ def test_to_braket_random_circuit():
         protocols.unitary(cirq_circuit),
         atol=1e-7,
     )
+
+
+def test_to_braket_mixed_qubit_types_preserves_line_qubit_indices():
+    """A non-LineQubit alongside LineQubits must not renumber them.
+
+    Relabelling every qubit in sorted order would send an operation on
+    ``LineQubit(10)`` to Braket target 0 or 1, silently changing which
+    physical qubit it addresses. Only the non-LineQubits are assigned, and
+    they take the lowest index no LineQubit already occupies.
+    """
+    line, other = LineQubit(10), ops.NamedQubit("aux")
+    cirq_circuit = Circuit(ops.X(line), ops.CNOT(line, other))
+
+    braket_circuit = to_braket(cirq_circuit)
+
+    targets = sorted(
+        {int(t) for instr in braket_circuit.instructions for t in instr.target}
+    )
+    assert targets == [0, 10]
+
+
+def test_to_braket_measurement_only_qubit_does_not_renumber():
+    """A non-LineQubit that appears only in a measurement is harmless.
+
+    Measurements are dropped by the translator, so a circuit whose gates
+    are all on LineQubits must keep its indices even when a measurement
+    mentions another qubit type.
+    """
+    cirq_circuit = Circuit(
+        ops.X(LineQubit(10)),
+        ops.CNOT(LineQubit(10), LineQubit(11)),
+        ops.measure(ops.NamedQubit("aux"), key="m"),
+    )
+
+    with pytest.warns(UserWarning, match="Measurement gate removed"):
+        braket_circuit = to_braket(cirq_circuit)
+
+    targets = sorted(
+        {int(t) for instr in braket_circuit.instructions for t in instr.target}
+    )
+    assert targets == [10, 11]
+
+
+def test_to_braket_assigned_index_avoids_existing_line_qubits():
+    """An assigned index never collides with a LineQubit already present."""
+    cirq_circuit = Circuit(
+        ops.X(LineQubit(0)),
+        ops.CNOT(LineQubit(0), ops.NamedQubit("aux")),
+    )
+
+    braket_circuit = to_braket(cirq_circuit)
+
+    targets = sorted(
+        {int(t) for instr in braket_circuit.instructions for t in instr.target}
+    )
+    assert targets == [0, 1]

--- a/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
+++ b/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
@@ -9,7 +9,7 @@ import pytest
 from braket.circuits import Circuit as BKCircuit
 from braket.circuits import Instruction
 from braket.circuits import gates as braket_gates
-from cirq import Circuit, LineQubit, ops, protocols, testing
+from cirq import Circuit, GridQubit, LineQubit, ops, protocols, testing
 
 from mitiq.interface.mitiq_braket.conversions import from_braket, to_braket
 from mitiq.utils import _equal
@@ -382,3 +382,77 @@ def test_to_from_braket_common_three_qubit_gates(common_gate):
     )
 
     assert _equal(test_circuit, cirq_circuit, require_qubit_equality=True)
+
+
+@pytest.mark.parametrize(
+    "qubits",
+    [
+        LineQubit.range(3),
+        [LineQubit(10), LineQubit(11), LineQubit(12)],
+        ops.NamedQubit.range(3, prefix="q"),
+        list(GridQubit.rect(1, 3)),
+    ],
+)
+def test_to_braket_accepts_any_qubit_type(qubits):
+    """Braket indexes qubits by integer, so non-LineQubits are relabelled.
+
+    ``to_braket`` read ``op.qubits[0].x`` directly, which only exists on
+    ``LineQubit``: a ``NamedQubit`` or ``GridQubit`` circuit raised
+    ``AttributeError: 'NamedQubit' object has no attribute 'x'``. Circuits
+    from ``cirq.testing.random_circuit`` use ``NamedQubit``, so they could
+    not be converted at all.
+    """
+    cirq_circuit = Circuit(
+        ops.H(qubits[0]),
+        ops.CNOT(qubits[0], qubits[1]),
+        ops.X(qubits[2]),
+    )
+
+    test_circuit = from_braket(to_braket(cirq_circuit))
+
+    testing.assert_allclose_up_to_global_phase(
+        protocols.unitary(test_circuit),
+        protocols.unitary(cirq_circuit),
+        atol=1e-7,
+    )
+
+
+def test_to_braket_preserves_line_qubit_indices():
+    """Relabelling must not renumber a circuit that is already LineQubits.
+
+    ``test_to_from_braket_non_zero_qubit`` depends on the indices being
+    carried through, so the relabelling has to be a no-op for LineQubits
+    even when they do not start at zero.
+    """
+    qubits = [LineQubit(10), LineQubit(11), LineQubit(12)]
+    cirq_circuit = Circuit(
+        ops.X(qubits[0]),
+        ops.CNOT(qubits[0], qubits[1]),
+        ops.CZ(qubits[1], qubits[2]),
+    )
+
+    braket_circuit = to_braket(cirq_circuit)
+
+    targets = sorted(
+        {int(t) for instr in braket_circuit.instructions for t in instr.target}
+    )
+    assert targets == [10, 11, 12]
+
+
+def test_to_braket_random_circuit():
+    """``cirq.testing.random_circuit`` output converts.
+
+    It builds circuits on ``NamedQubit``, which is what surfaced the
+    missing relabelling.
+    """
+    cirq_circuit = testing.random_circuit(
+        3, n_moments=6, op_density=0.8, random_state=5
+    )
+
+    test_circuit = from_braket(to_braket(cirq_circuit))
+
+    testing.assert_allclose_up_to_global_phase(
+        protocols.unitary(test_circuit),
+        protocols.unitary(cirq_circuit),
+        atol=1e-7,
+    )


### PR DESCRIPTION
### Description

`to_braket` reads `op.qubits[0].x`, an attribute that only exists on `cirq.LineQubit`, so every other qubit type raises:

```
AttributeError: 'NamedQubit' object has no attribute 'x'
AttributeError: 'GridQubit'  object has no attribute 'x'
```

This is reachable through the public API — `convert_from_mitiq(circuit, "braket")` on a NamedQubit circuit surfaces it as a `CircuitConversionError` wrapping that `AttributeError`. It also means output from **`cirq.testing.random_circuit`** cannot be converted at all, since that helper builds circuits on `NamedQubit`:

```python
>>> circuit = cirq.testing.random_circuit(3, n_moments=6, op_density=0.8, random_state=5)
>>> to_braket(circuit)
AttributeError: 'NamedQubit' object has no attribute 'x'
```

### Fix

Braket addresses qubits by integer index, so `to_braket` now relabels to `LineQubit` in sorted order at the entry point. Doing it there rather than at the three separate `cast(LineQubit, ...).x` sites keeps it to one place, and the cast annotations become true rather than aspirational.

**Relabelling is skipped when every qubit is already a `LineQubit`**, which matters: a circuit on `LineQubit(10..12)` must still convert to Braket targets `10..12`, because `test_to_from_braket_non_zero_qubit` depends on the indices carrying through. `test_to_braket_preserves_line_qubit_indices` now pins that explicitly.

### Verified

Round-trip `cirq -> braket -> cirq`, phase-invariant max deviation of the unitary:

| qubit type | error |
|---|---|
| `LineQubit.range(3)` | 0.0e+00 |
| `LineQubit(10), (11), (12)` | 0.0e+00 |
| `NamedQubit.range(3)` | 0.0e+00 |
| `GridQubit.rect(1, 3)` | 0.0e+00 |
| `random_circuit(3, 6)` | 0.0e+00 |

```
pytest mitiq/interface/mitiq_braket/    34 passed
ruff check                             All checks passed!
ruff format --check                    2 files already formatted
```

Control: on the previous implementation **3 of the new tests fail** (NamedQubit, GridQubit, random_circuit) while the two `LineQubit` parametrizations pass either way — so the tests cover the new capability without masking the existing behaviour.

### How this came up

While measuring qbraid's transpiler coverage for #2802 I compared mitiq's braket converter against `qbraid`'s on a set of circuits, and `random_circuit` was the one case where they diverged: qbraid round-tripped it exactly, mitiq raised. Worth noting for that discussion that qbraid's converter handles `NamedQubit` but **fails differently on `GridQubit`** (`ValueError: Operator qubit count 2 must be equal to size`), so after this change mitiq's own converter accepts strictly more input than the upstream one.

Assisted-by: Claude (Anthropic). Every number above was measured, per the AI use policy in `CONTRIBUTING.md`.
