### PR TITLE
Fix AttributeError when raw OpenQASM strings are passed to error mitigation techniques

### DIFF
--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -305,6 +305,22 @@ def atomic_one_to_many_converter(
     return qprogram_modifier
 
 
+def _wrap_openqasm_string(circuit: QPROGRAM) -> QPROGRAM:
+    """Wrap a bare OpenQASM ``str`` in :class:`~mitiq.typing.QasmStringType`.
+
+    Downstream code (both here and inside :func:`convert_to_mitiq`) reads
+    ``circuit.__module__`` to dispatch by frontend. A plain ``str`` has no
+    ``__module__`` attribute; ``QasmStringType`` does. Wrapping preserves
+    the string content and lets the rest of the pipeline treat all inputs
+    uniformly.
+    """
+    if isinstance(circuit, str) and not hasattr(circuit, "__module__"):
+        from mitiq.typing import QasmStringType
+
+        return QasmStringType(circuit)
+    return circuit
+
+
 def accept_qprogram_and_validate(
     cirq_circuit_modifier: Callable[..., Any],
     one_to_many: bool = False,
@@ -328,6 +344,11 @@ def accept_qprogram_and_validate(
 
     @wraps(cirq_circuit_modifier)
     def new_function(circuit: QPROGRAM, *args: Any, **kwargs: Any) -> QPROGRAM:
+        # A bare ``str`` (OpenQASM program) has no ``__module__``. Mirror the
+        # wrap done in :func:`convert_to_mitiq` so downstream ``.__module__``
+        # reads on both the input and the returned circuit stay valid.
+        circuit = _wrap_openqasm_string(circuit)
+
         # Pre atomic conversion
         if "qiskit" in circuit.__module__:
             from qiskit.transpiler.passes import RemoveBarriers

--- a/mitiq/interface/mitiq_openqasm/tests/test_openqasm_pipeline.py
+++ b/mitiq/interface/mitiq_openqasm/tests/test_openqasm_pipeline.py
@@ -1,0 +1,207 @@
+# Copyright (C) Unitary Foundation
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""End-to-end tests that error-mitigation entrypoints accept raw OpenQASM
+program strings (the frontend added in v0.49.0)."""
+
+import numpy as np
+import pytest
+from openqasm3 import parse
+
+from mitiq import ddd, lre, pec, zne
+from mitiq.ddd import rules
+from mitiq.interface import convert_to_mitiq
+from mitiq.pec.representations import (
+    represent_operations_in_circuit_with_local_depolarizing_noise,
+)
+from mitiq.pt import (
+    generate_pauli_twirl_variants,
+    twirl_CNOT_gates,
+    twirl_CZ_gates,
+)
+from mitiq.typing import QasmStringType
+
+QASM3_TWO_QUBIT = """OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q;
+h q[0];
+cx q[0], q[1];
+"""
+
+QASM2_TWO_QUBIT = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+h q[0];
+cx q[0], q[1];
+"""
+
+QASM3_MEAS = """OPENQASM 3.0;
+include "stdgates.inc";
+qubit[2] q;
+bit[2] c;
+h q[0];
+cx q[0], q[1];
+c = measure q;
+"""
+
+QASM3_MULTI_REG = """OPENQASM 3.0;
+include "stdgates.inc";
+qubit[1] a;
+qubit[1] b;
+h a[0];
+cx a[0], b[0];
+"""
+
+
+def _executor(_circuit):
+    return 0.5
+
+
+def _assert_qasm_list(circuits, expected_len):
+    """Assert circuits is a list of QASM strings that re-parse as OpenQASM."""
+    assert isinstance(circuits, list)
+    assert len(circuits) == expected_len
+    for c in circuits:
+        assert isinstance(c, str)
+        # The current mitiq to_openqasm implementation emits OpenQASM 2.0
+        # via the qiskit backend. Parsing with openqasm3 handles both.
+        parse(c)
+
+
+# ---- Regression: bare str used to crash with AttributeError ----
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_zne_construct_circuits_accepts_openqasm_string(qasm):
+    scale_factors = [1.0, 3.0, 5.0]
+    out = zne.construct_circuits(qasm, scale_factors=scale_factors)
+    _assert_qasm_list(out, len(scale_factors))
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_zne_execute_with_zne_accepts_openqasm_string(qasm):
+    result = zne.execute_with_zne(qasm, _executor)
+    assert isinstance(result, float)
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_ddd_construct_circuits_accepts_openqasm_string(qasm):
+    out = ddd.construct_circuits(qasm, rule=rules.xx, num_trials=2)
+    _assert_qasm_list(out, 2)
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_ddd_execute_with_ddd_accepts_openqasm_string(qasm):
+    result = ddd.execute_with_ddd(qasm, _executor, rule=rules.xx)
+    assert isinstance(result, float)
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_lre_construct_circuits_accepts_openqasm_string(qasm):
+    out = lre.construct_circuits(qasm, degree=2, fold_multiplier=1)
+    assert isinstance(out, list) and len(out) > 0
+    for c in out:
+        assert isinstance(c, str)
+        parse(c)
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_lre_execute_with_lre_accepts_openqasm_string(qasm):
+    result = lre.execute_with_lre(qasm, _executor, degree=2, fold_multiplier=1)
+    assert isinstance(result, float)
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_pt_generate_pauli_twirl_variants_accepts_openqasm_string(qasm):
+    variants = generate_pauli_twirl_variants(qasm, num_circuits=3)
+    _assert_qasm_list(variants, 3)
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_pt_twirl_CNOT_gates_accepts_openqasm_string(qasm):
+    variants = twirl_CNOT_gates(qasm, num_circuits=2)
+    _assert_qasm_list(variants, 2)
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_pt_twirl_CZ_gates_accepts_openqasm_string(qasm):
+    variants = twirl_CZ_gates(qasm, num_circuits=2)
+    _assert_qasm_list(variants, 2)
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_pec_construct_circuits_accepts_openqasm_string(qasm):
+    cirq_circuit, _ = convert_to_mitiq(qasm)
+    reps = represent_operations_in_circuit_with_local_depolarizing_noise(
+        cirq_circuit, noise_level=0.01
+    )
+    circuits, signs, norm = pec.construct_circuits(
+        qasm,
+        representations=reps,
+        num_samples=4,
+        random_state=0,
+        full_output=True,
+    )
+    _assert_qasm_list(circuits, 4)
+    assert np.asarray(signs).shape == (4,)
+    assert isinstance(norm, float)
+
+
+@pytest.mark.parametrize("qasm", [QASM3_TWO_QUBIT, QASM2_TWO_QUBIT])
+def test_pec_execute_with_pec_accepts_openqasm_string(qasm):
+    cirq_circuit, _ = convert_to_mitiq(qasm)
+    reps = represent_operations_in_circuit_with_local_depolarizing_noise(
+        cirq_circuit, noise_level=0.01
+    )
+    result = pec.execute_with_pec(
+        qasm,
+        _executor,
+        representations=reps,
+        num_samples=4,
+        random_state=0,
+    )
+    assert isinstance(result, float)
+
+
+# ---- Type-preservation ----
+
+
+def test_construct_circuits_return_is_qasm_string_subclass():
+    """The wrapped input propagates: outputs are QasmStringType instances,
+    which have a ``__module__`` attribute so downstream ``.__module__`` reads
+    do not re-crash on the return path."""
+    out = zne.construct_circuits(QASM3_TWO_QUBIT, scale_factors=[1.0, 3.0])
+    for c in out:
+        assert isinstance(c, QasmStringType)
+        assert hasattr(c, "__module__")
+        assert "openqasm" in c.__module__
+
+
+# ---- Additional real-world QASM shapes ----
+
+
+def test_zne_with_measurement_bearing_qasm():
+    """Circuit with an explicit measurement instruction."""
+    out = zne.construct_circuits(QASM3_MEAS, scale_factors=[1.0, 3.0])
+    _assert_qasm_list(out, 2)
+
+
+def test_zne_with_multi_qreg_qasm():
+    """Circuit with more than one quantum register."""
+    out = zne.construct_circuits(QASM3_MULTI_REG, scale_factors=[1.0, 3.0])
+    _assert_qasm_list(out, 2)
+
+
+# ---- Negative test: garbage input surfaces CircuitConversionError,
+# not AttributeError ----
+
+
+def test_garbage_qasm_raises_circuit_conversion_error():
+    from mitiq.interface import CircuitConversionError
+
+    with pytest.raises(CircuitConversionError):
+        zne.construct_circuits(
+            "this is not valid qasm", scale_factors=[1.0, 3.0]
+        )


### PR DESCRIPTION
## Description

Fixes #3121.

Raw OpenQASM strings (both `OPENQASM 3.0;` and `OPENQASM 2.0;`) crash 11 technique
entrypoints across ZNE, DDD, LRE, PT, and PEC with
`AttributeError: 'str' object has no attribute '__module__'`.

**Root cause:** `convert_to_mitiq` wraps bare `str` inputs in `QasmStringType` (which
carries a `__module__` marker), but `accept_qprogram_and_validate.new_function` in
`mitiq/interface/conversions.py` reads `circuit.__module__` on the raw incoming argument
*before* any conversion — so every technique whose circuit-processing step goes through
this decorator crashes on a plain string, while direct `convert_to_mitiq` calls work.
PEC's existing tests pass only because they pre-convert to Cirq before calling, so CI
never exercised the raw-string path.

**The fix** adds a small `_wrap_openqasm_string` helper and calls it at the decorator's
entry, mirroring the exact idiom already used in `convert_to_mitiq`. The wrap propagates
through the pipeline, so both the input-side `__module__` read and the return conversion
work: `construct_circuits`-style calls on a QASM string return `QasmStringType`
instances whose contents re-parse as valid QASM. A helper function (rather than an
inline check) is needed because the `isinstance(circuit, str)` narrowing otherwise
propagates past the branch and breaks mypy on the `.copy()` call in the qiskit
sub-branch.

Before, on `main` (3e1833d):

```
>>> zne.execute_with_zne(qasm_string, executor)
AttributeError: 'str' object has no attribute '__module__'
```

After: returns the extrapolated `float`, for all 11 previously crashing entrypoints, in
both QASM dialects. Invalid strings now surface a `CircuitConversionError` instead of an
`AttributeError`.

## Tests

New file `mitiq/interface/mitiq_openqasm/tests/test_openqasm_pipeline.py` (26 tests):

- all 11 affected entrypoints, parametrized over OpenQASM 3.0 and 2.0 inputs,
- return-type preservation (`construct_circuits` on a QASM string returns QASM strings),
- measurement-bearing and multi-register circuits,
- a negative test asserting garbage input raises `CircuitConversionError`.

The new tests fail 26/26 on current `main` and pass 26/26 with this patch.

## Verified locally

```
uv run pytest -n auto -q --ignore=mitiq/interface/mitiq_pyquil
  2594 passed, 2 xfailed        (main at 3e1833d: 2568 passed, 2 xfailed)
uv run mypy mitiq               Success: no issues found in 113 source files
uv run ruff check               All checks passed!
uv run ruff format --check      3 files already formatted (changed files)
```

Python 3.11.9, cirq-core 1.6.1, qiskit 2.1.2, Linux. `make test-pyquil` was not run
(needs QVM/quilc servers); this change does not touch `mitiq/interface/mitiq_pyquil`.

## Out of scope

- `experimental.trex.execute_with_trex` fails on converted OpenQASM input for an
  unrelated reason (`KeyError: cirq.LineQubit(0)` from a hardcoded qubit in `trex.py`)
  — I'll file that separately.
- Converted QASM-string outputs are currently serialized via the QASM 2 emitter
  regardless of input dialect; that is pre-existing behavior and unchanged here.

## AI use

I used Claude (Anthropic)  while investigating and writing this change.
I chose the approach, reviewed every line, and reran the reproducer, the new tests, the
full suite, and the lint/type checks above myself. I can explain and defend any part of
it. The commit carries an `Assisted-by:` trailer.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant
  Unitary Foundation the right to provide additional permissions as described in
  section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I updated the documentation where relevant. *(No user-facing docs changes needed — behavior now matches what the docs already claim.)*