### PR TITLE
Ship py.typed marker so mitiq's type hints reach downstream users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,3 +159,6 @@ exclude_lines = [
 
 [tool.setuptools.packages.find]
 where = ["."]
+
+[tool.setuptools.package-data]
+mitiq = ["py.typed"]


### PR DESCRIPTION
According to [PEP 561](https://peps.python.org/pep-0561/#packaging-type-information), `py.typed` is a necessary file to indicate to downstream packages that you are providing type hints. TIL.

---

Disclosure: the code in this PR was written by an AI assistant (Claude Opus 5) under my direction.