### PR TITLE
Fix filterwarnings regex so experimental FutureWarnings are suppressed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ filterwarnings = [
     'ignore::DeprecationWarning',
     # Experimental modules emit FutureWarning by design; suppress in test suite
     # since the warning behavior is covered by mitiq/tests/test_experimental.py
-    'ignore:mitiq\.\w+ is experimental:FutureWarning',
+    'ignore:mitiq\.[\w.]+ is experimental:FutureWarning',
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Suppress all future warnings. These were not previously caught since the modules are `mitiq.experimental.pea` (for example), where the regex would not capture the last part of the module `pea`.

---

Disclosure: the code in this PR was written by an AI assistant (Claude Opus 5) under my direction.