### PR TITLE
Preserve qubit indices when post-selecting measurement results

### DIFF
--- a/mitiq/rem/post_select.py
+++ b/mitiq/rem/post_select.py
@@ -29,6 +29,10 @@ def post_select(
         inverted: Invert the selector predicate so that bitstrings which obey
             ``selector(bitstring) == False`` are selected and returned.
     """
+    selected = [bits for bits in result.result if selector(bits) != inverted]
     return MeasurementResult(
-        [bits for bits in result.result if selector(bits) != inverted]
+        selected,
+        # A ``MeasurementResult`` without bitstrings has no qubits, so the
+        # indices can only be carried over when some shots survive.
+        result.qubit_indices if selected else None,
     )

--- a/mitiq/rem/tests/test_post_select.py
+++ b/mitiq/rem/tests/test_post_select.py
@@ -77,3 +77,14 @@ def test_post_select_edge_cases():
 
     assert post_select(samples, lambda bits: sum(bits) == -1).result == []
     assert post_select(samples, lambda bits: sum(bits) == 23).result == []
+
+
+def test_post_select_preserves_qubit_indices():
+    res = MeasurementResult(
+        [[0, 1], [1, 0], [1, 1], [0, 0]], qubit_indices=(2, 5)
+    )
+
+    selected = post_select(res, lambda bits: sum(bits) == 1)
+
+    assert selected.qubit_indices == (2, 5)
+    assert selected.filter_qubits([5]).tolist() == [[1], [0]]


### PR DESCRIPTION
## Description

`post_select` rebuilt the returned `MeasurementResult` from the surviving bitstrings only, so any non-default `qubit_indices` on the input were silently replaced by `tuple(range(nqubits))`. Since `MeasurementResult.filter_qubits` looks bitstrings up by qubit index, estimating an `Observable` supported on a subset of qubits after post-selection raised `KeyError` — exactly the case the `MeasurementResult` docstring warns to pass `qubit_indices` for.

```python
mr = MeasurementResult([[0, 1], [1, 0], [1, 1], [0, 0]], qubit_indices=(2, 5))
post_select(mr, lambda bits: sum(bits) == 1).qubit_indices  # (0, 1), was (2, 5)
Observable(PauliString("ZZ", support=(2, 5)))._expectation_from_measurements([...])  # KeyError: 2
```

The fix carries the input qubit indices over to the post-selected result, falling back to the default when no shots survive (a `MeasurementResult` with no bitstrings has no qubits, so it cannot hold qubit indices). Results with default indices are unaffected.

Verified: added a regression test that fails on `main` and passes here; `pytest mitiq` = 2581 passed / 2 xfailed (`mitiq_pyquil` excluded, needs a local QVM); `ruff check` + `ruff format --check` clean; `mypy mitiq` clean; and an end-to-end run of a Bell pair on qubits 2 and 5 inside a 6-qubit register where `Observable(PauliString("ZZ", support=(2, 5)))` now evaluates to 1.0 both before and after post-selection instead of raising.

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

- [x] I added unit tests for new code.
- [x] I used type hints in function signatures.
- [x] I used Google-style docstrings for functions.
- [ ] I updated the documentation where relevant.