### PR TITLE
Fix batched Executor.evaluate slicing for multi-group observables

### DIFF
--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -261,7 +261,7 @@ class Executor:
                 observable._expectation_from_measurements(
                     all_results[i : i + result_step]
                 )
-                for i in range(len(all_results) // result_step)
+                for i in range(0, len(all_results), result_step)
             ]
 
         else:

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -261,6 +261,28 @@ def test_executor_evaluate_measurements(execute):
 
 
 @pytest.mark.parametrize(
+    "execute", [executor_measurements_typed, executor_measurements_batched]
+)
+def test_executor_evaluate_measurements_multiple_groups(execute):
+    # X and Z do not qubit-wise commute, so each input circuit is measured
+    # with two different circuits, one per group.
+    obs = Observable(PauliString("X"), PauliString("Z"))
+    assert obs.ngroups == 2
+
+    q = cirq.LineQubit(0)
+    circuits = [
+        cirq.Circuit(cirq.I.on(q)),  # <X> + <Z> = 0 + 1.
+        cirq.Circuit(cirq.H.on(q)),  # <X> + <Z> = 1 + 0.
+        cirq.Circuit(cirq.X.on(q)),  # <X> + <Z> = 0 - 1.
+    ]
+
+    results = Executor(execute).evaluate(circuits, obs)
+
+    assert len(results) == len(circuits)
+    assert np.allclose(results, [1, 1, -1], atol=0.1)
+
+
+@pytest.mark.parametrize(
     "execute", [executor_density_matrix_typed, executor_density_matrix_batched]
 )
 def test_executor_evaluate_density_matrix(execute):


### PR DESCRIPTION
### Problem

When an executor returns `MeasurementResult` and the observable partitions into more than one qubit-wise-commuting group, `Executor.evaluate` runs `ngroups` circuits per input circuit and then regroups the results. The regrouping used a stride of one instead of `ngroups`:

```python
all_results[i : i + result_step] for i in range(len(all_results) // result_step)
```

So every circuit after the first was paired with measurement data belonging to other circuits, and the trailing results were never used.

Reproduction on `main` (`Observable(PauliString("X"), PauliString("Z"))` has 2 groups):

```python
obs = Observable(PauliString("X"), PauliString("Z"))
circuits = [Circuit(I(q)), Circuit(H(q)), Circuit(X(q))]   # <X>+<Z> = 1, 1, -1
Executor(execute).evaluate(circuits, obs)
# main: [0.99, 2.00, 1.01]      <- wrong
# here: [1.01, 1.01, -0.99]
```

Evaluating the circuits one at a time already gave the right answers, since only the `i = 0` slice was correct. This reaches users through `execute_with_zne` and friends, which pass all scaled circuits to `evaluate` in one call.

### Fix

Slice with a stride of `result_step`. One-line change in `mitiq/executor/executor.py`.

### Verification

- Added `test_executor_evaluate_measurements_multiple_groups` (serial and batched executors); confirmed it fails on `main` and passes with the fix. The existing `test_executor_evaluate_measurements` only used a single-group observable, which is why this was not caught.
- `pytest mitiq` (excluding `mitiq_pyquil`, which needs a local QVM): 2583 passed, 2 xfailed.
- `ruff check` + `ruff format --check` clean, `mypy mitiq` clean.
- Exercised end to end with the snippet above.

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.