### PR TITLE
Set Richardson fit order from distinct scale factors

### DIFF
--- a/docs/source/guide/zne-3-options.md
+++ b/docs/source/guide/zne-3-options.md
@@ -408,7 +408,8 @@ adaptive_factory = zne.inference.AdaExpFactory(steps=5, asymptote=0.5)
 
 ```{tip}
 Richardson extrapolation is equivalent to an exact polynomial interpolation.
-This means that a {class}`.RichardsonFactory` object is equivalent to a {class}`.PolyFactory` with `order=len(scale_factors) - 1`.
+This means that a {class}`.RichardsonFactory` object is equivalent to a {class}`.PolyFactory` with `order=len(set(scale_factors)) - 1`.
+For distinct scale factors that is simply `len(scale_factors) - 1`; counting repeated scale factors would request a degree the data cannot determine.
 ```
 
 ## Running ZNE with advanced options

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -913,8 +913,14 @@ class RichardsonFactory(BatchedFactory):
             parameters, use the ``reduce`` method.
         """
         # Richardson extrapolation is a particular case of a polynomial fit
-        # with order equal to the number of data points minus 1.
-        order = len(scale_factors) - 1
+        # with order equal to the number of *distinct* data points minus 1.
+        # Counting repeated scale factors would request a degree the data
+        # cannot determine: np.polyfit then returns a rank-deficient
+        # least-squares fit, which silently misses the zero-noise limit even
+        # when the underlying signal is exactly polynomial. Repeating a scale
+        # factor to average shot noise is legitimate, so reduce the order
+        # rather than rejecting the input.
+        order = len(set(scale_factors)) - 1
         return PolyFactory.extrapolate(
             scale_factors, exp_values, order, full_output
         )

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -318,6 +318,71 @@ def test_richardson_extr(test_f: Callable[[float], float]):
     )
 
 
+@mark.parametrize(
+    "scale_factors",
+    [
+        [1.0, 1.0, 2.0],
+        [1.0, 2.0, 2.0],
+        [1.0, 1.0, 2.0, 2.0],
+    ],
+)
+def test_richardson_extr_repeated_scale_factors_linear(scale_factors):
+    """Richardson stays exact on a linear signal when scale factors repeat.
+
+    The fit order is set by the number of *distinct* scale factors. Using the
+    raw count asks np.polyfit for a degree the data cannot determine, and the
+    rank-deficient least-squares result misses the zero-noise limit even for
+    an exactly polynomial signal. Repeating a scale factor to average shot
+    noise is legitimate, so this must extrapolate rather than degrade.
+
+    Two distinct scale factors determine a line, so f(0) is recovered exactly.
+    """
+
+    def exactly_linear(scale_factor: float) -> float:
+        return 1.0 - 0.1 * scale_factor
+
+    fac = RichardsonFactory(scale_factors=scale_factors)
+    for scale_factor in fac.get_scale_factors():
+        fac.push({"scale_factor": scale_factor}, exactly_linear(scale_factor))
+
+    assert np.isclose(fac.reduce(), exactly_linear(0.0), atol=CLOSE_TOL)
+
+
+def test_richardson_extr_repeated_scale_factors_quadratic():
+    """Three distinct scale factors still determine a quadratic exactly.
+
+    Each is measured twice, the idiom used to average shot noise. Counting
+    the six raw points would request a degree-5 fit through three abscissas.
+    """
+
+    def exactly_quadratic(scale_factor: float) -> float:
+        return 1.0 - 0.1 * scale_factor + 0.05 * scale_factor**2
+
+    scale_factors = [1.0, 1.0, 2.0, 2.0, 3.0, 3.0]
+    fac = RichardsonFactory(scale_factors=scale_factors)
+    for scale_factor in fac.get_scale_factors():
+        fac.push(
+            {"scale_factor": scale_factor}, exactly_quadratic(scale_factor)
+        )
+
+    assert np.isclose(fac.reduce(), exactly_quadratic(0.0), atol=CLOSE_TOL)
+
+
+def test_richardson_extr_all_scale_factors_equal():
+    """A single distinct scale factor carries no zero-noise information.
+
+    The order collapses to zero, so the fit is the mean of the measured
+    values. That is all one abscissa can support; the point of this test is
+    that the result is defined and finite rather than a rank-deficient
+    extrapolation far from every measured value.
+    """
+    fac = RichardsonFactory(scale_factors=[2.0, 2.0])
+    for scale_factor in fac.get_scale_factors():
+        fac.push({"scale_factor": scale_factor}, 0.7)
+
+    assert np.isclose(fac.reduce(), 0.7, atol=CLOSE_TOL)
+
+
 def test_fake_nodes_factory():
     """Test FakeNodesFactory in a specific regime in which the fake nodes
     interpolation method works well.


### PR DESCRIPTION
`RichardsonFactory` picks its polynomial order as `len(scale_factors) - 1`. When a scale factor repeats, that asks `np.polyfit` for a degree the data cannot determine, and the rank-deficient fit misses the zero-noise limit.

With a constant executor, so any correct extrapolation must return `1.0`:

```python
zne.execute_with_zne(circ, lambda c: 1.0, factory=RichardsonFactory(scale_factors=sfs))

sfs=[1.0, 2.0, 3.0]  ->  0.9999999999999989
sfs=[1.0, 1.0, 2.0]  ->  0.857142857142857
sfs=[1.0, 1.0]       ->  0.49999999999999983
```

`mitiq_polyfit` already turns numpy's `RankWarning` into an `ExtrapolationWarning`, so a warning does reach the user. The change here is that the returned value is right. Repeating a scale factor to average shot noise seems like a reasonable thing to do, so lowering the order looked better than rejecting the input.

**The fix:** `order = len(set(scale_factors)) - 1`. Distinct scale factors give the same order as before, so nothing else changes.

**What it does not do:** two distinct scale factors determine a line, so a quadratic sampled at `[1, 1, 2]` still is not recoverable — it goes from 0.79 to 0.90 against a true 1.0, better but not exact. The tests assert exactness only where the distinct abscissas support the signal's degree.

**Tests:** three cases in `test_richardson_extr_repeated_scale_factors_linear`, one quadratic sampled twice at each of three points, and the single-distinct-value case where the order collapses to 0 and the result is the mean. All 5 fail on `main`.

I did not find an existing issue for this. No caller in the repo passes duplicate scale factors (90 numeric `scale_factors` literals across `mitiq/` and `docs/`, none with a repeat), so this is a latent trap rather than a currently broken path — happy to close it if that makes it not worth the review time.

Locally `mitiq/zne/` is 161 passed, 1 xfailed. I skipped `test_zne.py` and `test_folding.py` because pennylane and pyquil are not installed in my environment; CI covers those.
