### PR TITLE
restrict dependabot updates to direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-type: "all"
     exclude-paths:
       - "INTEGRATIONS.txt"
     ignore:


### PR DESCRIPTION
## Description

Removes the `allow: dependency-type: all` override from Dependabot’s uv configuration.

This restores Dependabot’s default behavior: routine version-update PRs cover direct dependencies only, while Dependabot security updates can still remediate vulnerable dependencies recorded in `uv.lock`.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.